### PR TITLE
feat: add driver connection lifecycle mgmt to adhere to neo4j Driver expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+### Added
+
+- Enhanced Neo4j driver connection management with more robust error handling
+- Simplified connection state checking in Neo4jGraph
+
 ## 0.1.1
 
 ### Changed

--- a/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
+++ b/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
@@ -837,20 +837,7 @@ class Neo4jGraph(GraphStore):
         """
         Explicitly close the Neo4j driver connection.
         
-        This method releases the underlying database connection resources.
-        It is recommended to call this method when you are done using the graph
-        to prevent resource leaks and ensure proper cleanup.
-        
-        Best practices:
-        - Use within a try-finally block
-        - Prefer using the context manager (with statement)
-        
-        Example:
-            graph = Neo4jGraph(...)
-            try:
-                graph.query(...)
-            finally:
-                graph.close()
+        Delegates connection management to the Neo4j driver.
         """
         if hasattr(self, '_driver'):
             self._driver.close()

--- a/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
@@ -402,9 +402,9 @@ def test_backticks() -> None:
 
 def test_neo4j_context_manager() -> None:
     """Test that Neo4jGraph works correctly with context manager."""
-    url = os.environ.get("NEO4J_URI")
-    username = os.environ.get("NEO4J_USERNAME")
-    password = os.environ.get("NEO4J_PASSWORD")
+    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    username = os.environ.get("NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
     assert url is not None
     assert username is not None
     assert password is not None
@@ -423,9 +423,9 @@ def test_neo4j_context_manager() -> None:
 
 def test_neo4j_explicit_close() -> None:
     """Test that Neo4jGraph can be explicitly closed."""
-    url = os.environ.get("NEO4J_URI")
-    username = os.environ.get("NEO4J_USERNAME")
-    password = os.environ.get("NEO4J_PASSWORD")
+    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    username = os.environ.get("NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
     assert url is not None
     assert username is not None
     assert password is not None
@@ -447,9 +447,9 @@ def test_neo4j_explicit_close() -> None:
 
 def test_neo4j_error_after_close() -> None:
     """Test that Neo4jGraph operations raise proper errors after closing."""
-    url = os.environ.get("NEO4J_URI")
-    username = os.environ.get("NEO4J_USERNAME")
-    password = os.environ.get("NEO4J_PASSWORD")
+    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    username = os.environ.get("NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
     assert url is not None
     assert username is not None
     assert password is not None
@@ -482,9 +482,9 @@ def test_neo4j_error_after_close() -> None:
 
 def test_neo4j_concurrent_connections() -> None:
     """Test that multiple Neo4jGraph instances can be used independently."""
-    url = os.environ.get("NEO4J_URI")
-    username = os.environ.get("NEO4J_USERNAME")
-    password = os.environ.get("NEO4J_PASSWORD")
+    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    username = os.environ.get("NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
     assert url is not None
     assert username is not None
     assert password is not None
@@ -510,9 +510,9 @@ def test_neo4j_concurrent_connections() -> None:
 
 def test_neo4j_nested_context_managers() -> None:
     """Test that nested context managers work correctly."""
-    url = os.environ.get("NEO4J_URI")
-    username = os.environ.get("NEO4J_USERNAME")
-    password = os.environ.get("NEO4J_PASSWORD")
+    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    username = os.environ.get("NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
     assert url is not None
     assert username is not None
     assert password is not None
@@ -546,9 +546,9 @@ def test_neo4j_nested_context_managers() -> None:
 
 def test_neo4j_multiple_close() -> None:
     """Test that Neo4jGraph can be closed multiple times without error."""
-    url = os.environ.get("NEO4J_URI")
-    username = os.environ.get("NEO4J_USERNAME")
-    password = os.environ.get("NEO4J_PASSWORD")
+    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+    username = os.environ.get("NEO4J_USERNAME", "neo4j")
+    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
     assert url is not None
     assert username is not None
     assert password is not None

--- a/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
+++ b/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
@@ -1,7 +1,8 @@
-from langchain_neo4j.graphs.neo4j_graph import value_sanitize
-import pytest
 from unittest.mock import MagicMock, patch
-from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
+
+import pytest
+
+from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph, value_sanitize
 
 
 def test_value_sanitize_with_small_list():  # type: ignore[no-untyped-def]
@@ -46,96 +47,108 @@ def test_value_sanitize_with_dict_in_nested_list():  # type: ignore[no-untyped-d
 
 def test_driver_state_management():  # type: ignore[no-untyped-def]
     """Comprehensive test for driver state management."""
-    with patch('neo4j.GraphDatabase.driver') as mock_driver:
+    with patch("neo4j.GraphDatabase.driver") as mock_driver:
         # Setup mock driver
         mock_driver_instance = MagicMock()
         mock_driver.return_value = mock_driver_instance
         mock_driver_instance.execute_query = MagicMock(return_value=([], None, None))
 
         # Create graph instance
-        graph = Neo4jGraph(url="bolt://localhost:7687", username="neo4j", password="password")
-        
+        graph = Neo4jGraph(
+            url="bolt://localhost:7687", username="neo4j", password="password"
+        )
+
         # Store original driver
         original_driver = graph._driver
         original_driver.close = MagicMock()
 
         # Test initial state
-        assert hasattr(graph, '_driver')
-        
+        assert hasattr(graph, "_driver")
+
         # First close
         graph.close()
         original_driver.close.assert_called_once()
-        assert not hasattr(graph, '_driver')
-        
+        assert not hasattr(graph, "_driver")
+
         # Verify methods raise error when driver is closed
-        with pytest.raises(RuntimeError, match="Cannot perform operations - Neo4j connection has been closed"):
+        with pytest.raises(
+            RuntimeError,
+            match="Cannot perform operations - Neo4j connection has been closed",
+        ):
             graph.query("RETURN 1")
-        
-        with pytest.raises(RuntimeError, match="Cannot perform operations - Neo4j connection has been closed"):
+
+        with pytest.raises(
+            RuntimeError,
+            match="Cannot perform operations - Neo4j connection has been closed",
+        ):
             graph.refresh_schema()
 
 
 def test_close_method_removes_driver():  # type: ignore[no-untyped-def]
     """Test that close method removes the _driver attribute."""
-    with patch('neo4j.GraphDatabase.driver') as mock_driver:
+    with patch("neo4j.GraphDatabase.driver") as mock_driver:
         # Configure mock to return a mock driver
         mock_driver_instance = MagicMock()
         mock_driver.return_value = mock_driver_instance
-        
+
         # Configure mock execute_query to return empty result
         mock_driver_instance.execute_query = MagicMock(return_value=([], None, None))
-        
+
         # Add a _closed attribute to simulate driver state
         mock_driver_instance._closed = False
-        
-        graph = Neo4jGraph(url="bolt://localhost:7687", username="neo4j", password="password")
-        
+
+        graph = Neo4jGraph(
+            url="bolt://localhost:7687", username="neo4j", password="password"
+        )
+
         # Store a reference to the original driver
         original_driver = graph._driver
-        
+
         # Ensure driver's close method can be mocked
         original_driver.close = MagicMock()
-        
+
         # Call close method
         graph.close()
-        
+
         # Verify driver.close was called
         original_driver.close.assert_called_once()
-        
+
         # Verify _driver attribute is removed
-        assert not hasattr(graph, '_driver')
-        
+        assert not hasattr(graph, "_driver")
+
         # Verify second close does not raise an error
         graph.close()  # Should not raise any exception
 
 
 def test_multiple_close_calls_safe():  # type: ignore[no-untyped-def]
     """Test that multiple close calls do not raise errors."""
-    with patch('neo4j.GraphDatabase.driver') as mock_driver:
+    with patch("neo4j.GraphDatabase.driver") as mock_driver:
         # Configure mock to return a mock driver
         mock_driver_instance = MagicMock()
         mock_driver.return_value = mock_driver_instance
-        
+
         # Configure mock execute_query to return empty result
         mock_driver_instance.execute_query = MagicMock(return_value=([], None, None))
-        
+
         # Add a _closed attribute to simulate driver state
         mock_driver_instance._closed = False
-        
-        graph = Neo4jGraph(url="bolt://localhost:7687", username="neo4j", password="password")
-        
+
+        graph = Neo4jGraph(
+            url="bolt://localhost:7687", username="neo4j", password="password"
+        )
+
         # Store a reference to the original driver
         original_driver = graph._driver
-        
+
         # Mock the driver's close method
         original_driver.close = MagicMock()
-        
+
         # First close
         graph.close()
         original_driver.close.assert_called_once()
-        
+
         # Verify _driver attribute is removed
-        assert not hasattr(graph, '_driver')
-        
+        assert not hasattr(graph, "_driver")
+
         # Second close should not raise an error
         graph.close()  # Should not raise any exception

--- a/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
+++ b/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
@@ -1,4 +1,7 @@
 from langchain_neo4j.graphs.neo4j_graph import value_sanitize
+import pytest
+from unittest.mock import MagicMock, patch
+from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
 
 
 def test_value_sanitize_with_small_list():  # type: ignore[no-untyped-def]
@@ -39,3 +42,100 @@ def test_value_sanitize_with_dict_in_nested_list():  # type: ignore[no-untyped-d
     }
     expected_output = {"key1": "value1", "deeply_nested_lists": [[[[{}]]]]}
     assert value_sanitize(input_dict) == expected_output
+
+
+def test_driver_state_management():  # type: ignore[no-untyped-def]
+    """Comprehensive test for driver state management."""
+    with patch('neo4j.GraphDatabase.driver') as mock_driver:
+        # Setup mock driver
+        mock_driver_instance = MagicMock()
+        mock_driver.return_value = mock_driver_instance
+        mock_driver_instance.execute_query = MagicMock(return_value=([], None, None))
+
+        # Create graph instance
+        graph = Neo4jGraph(url="bolt://localhost:7687", username="neo4j", password="password")
+        
+        # Store original driver
+        original_driver = graph._driver
+        original_driver.close = MagicMock()
+
+        # Test initial state
+        assert hasattr(graph, '_driver')
+        
+        # First close
+        graph.close()
+        original_driver.close.assert_called_once()
+        assert not hasattr(graph, '_driver')
+        
+        # Verify methods raise error when driver is closed
+        with pytest.raises(RuntimeError, match="Cannot perform operations - Neo4j connection has been closed"):
+            graph.query("RETURN 1")
+        
+        with pytest.raises(RuntimeError, match="Cannot perform operations - Neo4j connection has been closed"):
+            graph.refresh_schema()
+
+
+def test_close_method_removes_driver():  # type: ignore[no-untyped-def]
+    """Test that close method removes the _driver attribute."""
+    with patch('neo4j.GraphDatabase.driver') as mock_driver:
+        # Configure mock to return a mock driver
+        mock_driver_instance = MagicMock()
+        mock_driver.return_value = mock_driver_instance
+        
+        # Configure mock execute_query to return empty result
+        mock_driver_instance.execute_query = MagicMock(return_value=([], None, None))
+        
+        # Add a _closed attribute to simulate driver state
+        mock_driver_instance._closed = False
+        
+        graph = Neo4jGraph(url="bolt://localhost:7687", username="neo4j", password="password")
+        
+        # Store a reference to the original driver
+        original_driver = graph._driver
+        
+        # Ensure driver's close method can be mocked
+        original_driver.close = MagicMock()
+        
+        # Call close method
+        graph.close()
+        
+        # Verify driver.close was called
+        original_driver.close.assert_called_once()
+        
+        # Verify _driver attribute is removed
+        assert not hasattr(graph, '_driver')
+        
+        # Verify second close does not raise an error
+        graph.close()  # Should not raise any exception
+
+
+def test_multiple_close_calls_safe():  # type: ignore[no-untyped-def]
+    """Test that multiple close calls do not raise errors."""
+    with patch('neo4j.GraphDatabase.driver') as mock_driver:
+        # Configure mock to return a mock driver
+        mock_driver_instance = MagicMock()
+        mock_driver.return_value = mock_driver_instance
+        
+        # Configure mock execute_query to return empty result
+        mock_driver_instance.execute_query = MagicMock(return_value=([], None, None))
+        
+        # Add a _closed attribute to simulate driver state
+        mock_driver_instance._closed = False
+        
+        graph = Neo4jGraph(url="bolt://localhost:7687", username="neo4j", password="password")
+        
+        # Store a reference to the original driver
+        original_driver = graph._driver
+        
+        # Mock the driver's close method
+        original_driver.close = MagicMock()
+        
+        # First close
+        graph.close()
+        original_driver.close.assert_called_once()
+        
+        # Verify _driver attribute is removed
+        assert not hasattr(graph, '_driver')
+        
+        # Second close should not raise an error
+        graph.close()  # Should not raise any exception


### PR DESCRIPTION
# Description
From [neo4j driver](https://github.com/neo4j/neo4j-python-driver/blob/5.0/src/neo4j/_sync/driver.py#L535-L554) impl: 

     def __del__(
        self,
        _unclosed_resource_warn=unclosed_resource_warn,
        _is_async_code=Util.is_async_code,
        _deprecation_warn=deprecation_warn,
    ):
        if not self._closed:
            _unclosed_resource_warn(self)
        # TODO: 6.0 - remove this
        if _is_async_code:
            return
        if not self._closed:
            _deprecation_warn(
                "Relying on Driver's destructor to close the session "
                "is deprecated. Please make sure to close the session. "
                "Use it as a context (`with` statement) or make sure to "
                "call `.close()` explicitly. Future versions of the "
                "driver will not close drivers automatically."
            )
            self.close()
>
>
We're currently relying on the driver destructor/python garbage collection. This PR adds basic context management which:
- enables use of graph connection using `with` statement. 
- enables explicit `close()` of driver connection
- raises `RuntimeError` when using closed connection

## Type of Change

- [x] New feature

## Complexity

Low

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual tests

## Checklist

- [x] Unit tests updated
- [x] Integration tests updated
- [x] CHANGELOG.md updated
