### PR TITLE
Removes LLMChain from GraphCypherQAChain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Added
 
-- Enhanced Neo4j driver connection management with more robust error handling
-- Simplified connection state checking in Neo4jGraph
+- Enhanced Neo4j driver connection management with more robust error handling.
+- Simplified connection state checking in Neo4jGraph.
+
+### Fixed
+
+- Removed deprecated LLMChain from GraphCypherQAChain to resolve instantiation issues with the use_function_response parameter.
 
 ## 0.1.1
 

--- a/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
+++ b/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
@@ -4,7 +4,7 @@ import os
 from unittest.mock import MagicMock
 
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.outputs import Generation, LLMResult
+from langchain_core.language_models.fake import FakeListLLM
 
 from langchain_neo4j.chains.graph_qa.cypher import GraphCypherQAChain
 from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
@@ -71,11 +71,7 @@ def test_cypher_generating_run() -> None:
         "WHERE m.title = 'Pulp Fiction' "
         "RETURN a.name"
     )
-    llm = MagicMock(spec=BaseLanguageModel)
-    llm.generate_prompt.side_effect = [
-        LLMResult(generations=[[Generation(text=query)]]),
-        LLMResult(generations=[[Generation(text="Bruce Willis")]]),
-    ]
+    llm = FakeListLLM(responses=[query, "Bruce Willis"])
     chain = GraphCypherQAChain.from_llm(
         llm=llm,
         graph=graph,
@@ -115,10 +111,7 @@ def test_cypher_top_k() -> None:
         "WHERE m.title = 'Pulp Fiction' "
         "RETURN a.name"
     )
-    llm = MagicMock(spec=BaseLanguageModel)
-    llm.generate_prompt.side_effect = [
-        LLMResult(generations=[[Generation(text=query)]])
-    ]
+    llm = FakeListLLM(responses=[query])
     chain = GraphCypherQAChain.from_llm(
         llm=llm,
         graph=graph,
@@ -156,11 +149,7 @@ def test_cypher_intermediate_steps() -> None:
         "WHERE m.title = 'Pulp Fiction' "
         "RETURN a.name"
     )
-    llm = MagicMock(spec=BaseLanguageModel)
-    llm.generate_prompt.side_effect = [
-        LLMResult(generations=[[Generation(text=query)]]),
-        LLMResult(generations=[[Generation(text="Bruce Willis")]]),
-    ]
+    llm = FakeListLLM(responses=[query, "Bruce Willis"])
     chain = GraphCypherQAChain.from_llm(
         llm=llm,
         graph=graph,
@@ -205,10 +194,7 @@ def test_cypher_return_direct() -> None:
         "WHERE m.title = 'Pulp Fiction' "
         "RETURN a.name"
     )
-    llm = MagicMock(spec=BaseLanguageModel)
-    llm.generate_prompt.side_effect = [
-        LLMResult(generations=[[Generation(text=query)]])
-    ]
+    llm = FakeListLLM(responses=[query])
     chain = GraphCypherQAChain.from_llm(
         llm=llm,
         graph=graph,

--- a/libs/neo4j/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/neo4j/tests/unit_tests/chains/test_graph_qa.py
@@ -3,7 +3,13 @@ from csv import DictReader
 from typing import Any, Dict, List
 
 from langchain.memory import ConversationBufferMemory, ReadOnlySharedMemory
-from langchain_core.prompts import PromptTemplate
+from langchain_core.messages import SystemMessage
+from langchain_core.prompts import (
+    ChatPromptTemplate,
+    HumanMessagePromptTemplate,
+    MessagesPlaceholder,
+    PromptTemplate,
+)
 
 from langchain_neo4j.chains.graph_qa.cypher import (
     GraphCypherQAChain,
@@ -64,8 +70,8 @@ def test_graph_cypher_qa_chain_prompt_selection_1() -> None:
         cypher_prompt=cypher_prompt,
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.prompt == qa_prompt  # type: ignore[union-attr]
-    assert chain.cypher_generation_chain.prompt == cypher_prompt
+    assert chain.qa_chain.first == qa_prompt  # type: ignore[attr-defined]
+    assert chain.cypher_generation_chain.first == cypher_prompt  # type: ignore[attr-defined]
 
 
 def test_graph_cypher_qa_chain_prompt_selection_2() -> None:
@@ -77,8 +83,8 @@ def test_graph_cypher_qa_chain_prompt_selection_2() -> None:
         return_intermediate_steps=False,
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.prompt == CYPHER_QA_PROMPT  # type: ignore[union-attr]
-    assert chain.cypher_generation_chain.prompt == CYPHER_GENERATION_PROMPT
+    assert chain.qa_chain.first == CYPHER_QA_PROMPT  # type: ignore[attr-defined]
+    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT  # type: ignore[attr-defined]
 
 
 def test_graph_cypher_qa_chain_prompt_selection_3() -> None:
@@ -94,8 +100,8 @@ def test_graph_cypher_qa_chain_prompt_selection_3() -> None:
         qa_llm_kwargs={"memory": readonlymemory},
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.prompt == CYPHER_QA_PROMPT  # type: ignore[union-attr]
-    assert chain.cypher_generation_chain.prompt == CYPHER_GENERATION_PROMPT
+    assert chain.qa_chain.first == CYPHER_QA_PROMPT  # type: ignore[attr-defined]
+    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT  # type: ignore[attr-defined]
 
 
 def test_graph_cypher_qa_chain_prompt_selection_4() -> None:
@@ -115,8 +121,8 @@ def test_graph_cypher_qa_chain_prompt_selection_4() -> None:
         qa_llm_kwargs={"prompt": qa_prompt, "memory": readonlymemory},
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.prompt == qa_prompt  # type: ignore[union-attr]
-    assert chain.cypher_generation_chain.prompt == cypher_prompt
+    assert chain.qa_chain.first == qa_prompt  # type: ignore[attr-defined]
+    assert chain.cypher_generation_chain.first == cypher_prompt  # type: ignore[attr-defined]
 
 
 def test_graph_cypher_qa_chain_prompt_selection_5() -> None:
@@ -142,6 +148,28 @@ def test_graph_cypher_qa_chain_prompt_selection_5() -> None:
         assert False
     except ValueError:
         assert True
+
+
+def test_graph_cypher_qa_chain_prompt_selection_6() -> None:
+    # Test function response prompt
+    function_response_system = "Respond as a pirate!"
+    response_prompt = ChatPromptTemplate.from_messages(
+        [
+            SystemMessage(content=function_response_system),
+            HumanMessagePromptTemplate.from_template("{question}"),
+            MessagesPlaceholder(variable_name="function_response"),
+        ]
+    )
+    chain = GraphCypherQAChain.from_llm(
+        llm=FakeLLM(),
+        graph=FakeGraphStore(),
+        verbose=True,
+        use_function_response=True,
+        function_response_system=function_response_system,
+        allow_dangerous_requests=True,
+    )
+    assert chain.qa_chain.first == response_prompt  # type: ignore[attr-defined]
+    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT  # type: ignore[attr-defined]
 
 
 def test_graph_cypher_qa_chain() -> None:

--- a/libs/neo4j/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/neo4j/tests/unit_tests/chains/test_graph_qa.py
@@ -70,8 +70,10 @@ def test_graph_cypher_qa_chain_prompt_selection_1() -> None:
         cypher_prompt=cypher_prompt,
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.first == qa_prompt  # type: ignore[attr-defined]
-    assert chain.cypher_generation_chain.first == cypher_prompt  # type: ignore[attr-defined]
+    assert hasattr(chain.qa_chain, "first")
+    assert chain.qa_chain.first == qa_prompt
+    assert hasattr(chain.cypher_generation_chain, "first")
+    assert chain.cypher_generation_chain.first == cypher_prompt
 
 
 def test_graph_cypher_qa_chain_prompt_selection_2() -> None:
@@ -83,8 +85,10 @@ def test_graph_cypher_qa_chain_prompt_selection_2() -> None:
         return_intermediate_steps=False,
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.first == CYPHER_QA_PROMPT  # type: ignore[attr-defined]
-    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT  # type: ignore[attr-defined]
+    assert hasattr(chain.qa_chain, "first")
+    assert chain.qa_chain.first == CYPHER_QA_PROMPT
+    assert hasattr(chain.cypher_generation_chain, "first")
+    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT
 
 
 def test_graph_cypher_qa_chain_prompt_selection_3() -> None:
@@ -100,8 +104,10 @@ def test_graph_cypher_qa_chain_prompt_selection_3() -> None:
         qa_llm_kwargs={"memory": readonlymemory},
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.first == CYPHER_QA_PROMPT  # type: ignore[attr-defined]
-    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT  # type: ignore[attr-defined]
+    assert hasattr(chain.qa_chain, "first")
+    assert chain.qa_chain.first == CYPHER_QA_PROMPT
+    assert hasattr(chain.cypher_generation_chain, "first")
+    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT
 
 
 def test_graph_cypher_qa_chain_prompt_selection_4() -> None:
@@ -121,8 +127,10 @@ def test_graph_cypher_qa_chain_prompt_selection_4() -> None:
         qa_llm_kwargs={"prompt": qa_prompt, "memory": readonlymemory},
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.first == qa_prompt  # type: ignore[attr-defined]
-    assert chain.cypher_generation_chain.first == cypher_prompt  # type: ignore[attr-defined]
+    assert hasattr(chain.qa_chain, "first")
+    assert chain.qa_chain.first == qa_prompt
+    assert hasattr(chain.cypher_generation_chain, "first")
+    assert chain.cypher_generation_chain.first == cypher_prompt
 
 
 def test_graph_cypher_qa_chain_prompt_selection_5() -> None:
@@ -168,8 +176,10 @@ def test_graph_cypher_qa_chain_prompt_selection_6() -> None:
         function_response_system=function_response_system,
         allow_dangerous_requests=True,
     )
-    assert chain.qa_chain.first == response_prompt  # type: ignore[attr-defined]
-    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT  # type: ignore[attr-defined]
+    assert hasattr(chain.qa_chain, "first")
+    assert chain.qa_chain.first == response_prompt
+    assert hasattr(chain.cypher_generation_chain, "first")
+    assert chain.cypher_generation_chain.first == CYPHER_GENERATION_PROMPT
 
 
 def test_graph_cypher_qa_chain() -> None:

--- a/libs/neo4j/tests/unit_tests/llms/fake_llm.py
+++ b/libs/neo4j/tests/unit_tests/llms/fake_llm.py
@@ -59,3 +59,6 @@ class FakeLLM(LLM):
         response = queries[list(queries.keys())[self.response_index]]
         self.response_index = self.response_index + 1
         return response
+
+    def bind_tools(self, tools: Any) -> None:
+        pass


### PR DESCRIPTION
# Description

This PR removes the deprecated `LLMChain` class from the `GraphCypherQAChain`. This fixes the bug which is caused when instantiating the `GraphCypherQAChain` with the `use_function_response` parameter.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Medium

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

## Checklist

- [X] Unit tests updated
- [X] Integration tests updated
- [x] CHANGELOG.md updated
