### PR TITLE
Moved LangChain core to 0.3.8

### DIFF
--- a/libs/neo4j/poetry.lock
+++ b/libs/neo4j/poetry.lock
@@ -1912,4 +1912,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "f53f504ff1199eb1021feeae70864948c106446ffbabaecfc6edee56f5ea2f13"
+content-hash = "5b6582f252d7d74f2fe188e34865d68cbe16bb3477f3e09a8855ad68f824597a"

--- a/libs/neo4j/pyproject.toml
+++ b/libs/neo4j/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain-core = "^0.3.1"
+langchain-core = "^0.3.8"
 neo4j = "^5.25.0"
 langchain = "^0.3.7"
 


### PR DESCRIPTION
# Description

Moves LangChain core dependency to 0.3.8


## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [X] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Checklist

- [ ] Unit tests updated
- [ ] Integration tests updated
- [ ] CHANGELOG.md updated
