### PR TITLE
Provide optional parameter for embedding dimension in Neo4jVector

### DIFF
--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -509,6 +509,7 @@ class Neo4jVector(VectorStore):
         relevance_score_fn: Optional[Callable[[float], float]] = None,
         index_type: IndexType = DEFAULT_INDEX_TYPE,
         graph: Optional[Neo4jGraph] = None,
+        embedding_dimension: Optional[int] = None,
     ) -> None:
         try:
             import neo4j
@@ -593,8 +594,11 @@ class Neo4jVector(VectorStore):
         self.search_type = search_type
         self._index_type = index_type
 
-        # Calculate embedding dimension
-        self.embedding_dimension = len(embedding.embed_query("foo"))
+        if embedding_dimension:
+            self.embedding_dimension = embedding_dimension
+        else:
+            # Calculate embedding dimension
+            self.embedding_dimension = len(embedding.embed_query("foo"))
 
         # Delete existing data if flagged
         if pre_delete_collection:
@@ -840,6 +844,7 @@ class Neo4jVector(VectorStore):
         ids: Optional[List[str]] = None,
         create_id_index: bool = True,
         search_type: SearchType = SearchType.VECTOR,
+        embedding_dimension: Optional[int] = None,
         **kwargs: Any,
     ) -> Neo4jVector:
         if ids is None:
@@ -851,6 +856,7 @@ class Neo4jVector(VectorStore):
         store = cls(
             embedding=embedding,
             search_type=search_type,
+            embedding_dimension=embedding_dimension,
             **kwargs,
         )
         # Check if the vector index already exists

--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -466,8 +466,8 @@ class Neo4jVector(VectorStore):
             (default: False). Useful for testing.
         effective_search_ratio: Controls the candidate pool size by multiplying $k
             to balance query accuracy and performance.
-        embedding_dimension: The dimension of the embeddings. If not provided, will query
-            the embedding model to calculate the dimension.
+        embedding_dimension: The dimension of the embeddings. If not provided,
+            will query the embedding model to calculate the dimension.
 
     Example:
         .. code-block:: python
@@ -1370,7 +1370,10 @@ class Neo4jVector(VectorStore):
         )
 
         if embedding_dimension:
-            embedding_dimension_from_existing, index_type = store.retrieve_existing_index()
+            (
+                embedding_dimension_from_existing,
+                index_type,
+            ) = store.retrieve_existing_index()
             if embedding_dimension_from_existing != embedding_dimension:
                 raise ValueError(
                     "The provided embedding function and vector index "
@@ -1452,7 +1455,10 @@ class Neo4jVector(VectorStore):
         )
 
         if embedding_dimension:
-            embedding_dimension_from_existing, index_type = store.retrieve_existing_index()
+            (
+                embedding_dimension_from_existing,
+                index_type,
+            ) = store.retrieve_existing_index()
             if embedding_dimension_from_existing != embedding_dimension:
                 raise ValueError(
                     "The provided embedding function and vector index "

--- a/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
+++ b/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
@@ -1022,3 +1022,22 @@ def test_select_relevance_score_fn_unsupported_strategy(
         f"Expected error message to contain '{expected_message}' "
         f"but got '{str(exc_info.value)}'"
     )
+
+
+def test_embedding_dimension_inconsistent_raises_value_error(neo4j_vector_factory: Any):
+    mock_embedding = MagicMock()
+    mock_embedding.embed_query.return_value = [0.1] * 64
+
+    with patch.object(
+        Neo4jVector, "retrieve_existing_index", return_value=(128, "NODE")
+    ):
+        with pytest.raises(ValueError) as exc_info:
+            neo4j_vector_factory(
+                method="from_existing_index",
+                embedding=mock_embedding,
+                index_name="test_index",
+            )
+    assert (
+        "The provided embedding function and vector index dimensions do not match."
+        in str(exc_info.value)
+    )

--- a/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
+++ b/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
@@ -1024,7 +1024,9 @@ def test_select_relevance_score_fn_unsupported_strategy(
     )
 
 
-def test_embedding_dimension_inconsistent_raises_value_error(neo4j_vector_factory: Any):
+def test_embedding_dimension_inconsistent_raises_value_error(
+    neo4j_vector_factory: Any,
+) -> None:
     mock_embedding = MagicMock()
     mock_embedding.embed_query.return_value = [0.1] * 64
 


### PR DESCRIPTION
# Description
From [this issue](https://github.com/langchain-ai/langchain-neo4j/issues/30).
When loading an existing index via Neo4jVector.from_existing_index(), a singleton of Neo4jVector is created, which in init calls [the embedding model to find the number of embedding dimensions.](https://github.com/langchain-ai/langchain-neo4j/blob/a6c8e139aa4beb505cb79c446a72d0c53a28e7ef/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py#L597).
This call to the embedding model is a headache in CICD, where you do not want to and can not call third-party embedding services during integration tests.


## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manual tests

## Checklist

- [x] Unit tests updated
- [x] Integration tests updated
- [ ] CHANGELOG.md updated
