### PR TITLE
Makes the source parameter of GraphDocument optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Next
 
+### Changed
+
+- Made the `source` parameter of `GraphDocument` optional and updated related methods to support this.
+
+### Fixed
+
+- Disabled warnings from the Neo4j driver for the Neo4jGraph class.
+
 ## 0.2.0
 
 ### Added

--- a/libs/neo4j/langchain_neo4j/graphs/graph_document.py
+++ b/libs/neo4j/langchain_neo4j/graphs/graph_document.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List, Optional, Union
 
 from langchain_core.documents import Document
 from langchain_core.load.serializable import Serializable
@@ -43,9 +43,10 @@ class GraphDocument(Serializable):
     Attributes:
         nodes (List[Node]): A list of nodes in the graph.
         relationships (List[Relationship]): A list of relationships in the graph.
-        source (Document): The document from which the graph information is derived.
+        source (Optional[Document]): The document from which the graph information is
+            derived.
     """
 
     nodes: List[Node]
     relationships: List[Relationship]
-    source: Document
+    source: Optional[Document] = None


### PR DESCRIPTION
# Description

This PR updates the `GraphDocument` class to make the `source` parameter optional. It also updates the `add_graph_documents` method of the `Neo4jGraph` class to work with this. This is to allow users to add nodes and relationships to a graph without the need for a source document.

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

## Checklist

- [X] Unit tests updated
- [ ] Integration tests updated
- [x] CHANGELOG.md updated
