### PR TITLE
Enhanced schema fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## Next
 
+### Added
+
+- Optional parameter to specify embedding dimension in `Neo4jVector`, avoiding the need to query the embedding model.
+
 ### Changed
 
 - Made the `source` parameter of `GraphDocument` optional and updated related methods to support this.
 
 ### Fixed
 
-- Disabled warnings from the Neo4j driver for the Neo4jGraph class.
+- Disabled warnings from the Neo4j driver for the Neo4jGraph class when enhanced_schema is set to True.
+- Resolved syntax errors in GraphCypherQAChain by ensuring node labels with spaces are correctly quoted in Cypher queries.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Disabled warnings from the Neo4j driver for the Neo4jGraph class when enhanced_schema is set to True.
+- Suppressed AggregationSkippedNull warnings raised by the Neo4j driver in the Neo4jGraph class when fetching the enhanced_schema.
 - Resolved syntax errors in GraphCypherQAChain by ensuring node labels with spaces are correctly quoted in Cypher queries.
 
 ## 0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
 ### Changed
 
 - Made the `source` parameter of `GraphDocument` optional and updated related methods to support this.
+- Suppressed AggregationSkippedNull warnings raised by the Neo4j driver in the Neo4jGraph class when fetching the enhanced_schema.
 
 ### Fixed
 
-- Suppressed AggregationSkippedNull warnings raised by the Neo4j driver in the Neo4jGraph class when fetching the enhanced_schema.
 - Resolved syntax errors in GraphCypherQAChain by ensuring node labels with spaces are correctly quoted in Cypher queries.
 
 ## 0.2.0

--- a/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
+++ b/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
@@ -546,7 +546,8 @@ class Neo4jGraph(GraphStore):
         }
         if self._enhanced_schema:
             schema_counts = self.query(
-                "CALL apoc.meta.graph() YIELD nodes, relationships "
+                "CALL apoc.meta.graph({sample: 1000, maxRels: 100}) "
+                "YIELD nodes, relationships "
                 "RETURN nodes, [rel in relationships | {name:apoc.any.property"
                 "(rel, 'type'), count: apoc.any.property(rel, 'count')}]"
                 " AS relationships"

--- a/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
+++ b/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
@@ -439,7 +439,7 @@ class Neo4jGraph(GraphStore):
             query (str): The Cypher query to execute.
             params (dict): The parameters to pass to the query.
             session_params (dict): Parameters to pass to the session used for executing
-                the query. Does nothing when use_execute_query is True.
+                the query.
 
         Returns:
             List[Dict[str, Any]]: The list of dictionaries containing the query results.

--- a/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
+++ b/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
@@ -569,7 +569,7 @@ class Neo4jGraph(GraphStore):
                         # Disable the
                         # Neo.ClientNotification.Statement.AggregationSkippedNull
                         # notifications raised by the use of collect in the enhanced
-                        # schema
+                        # schema query
                         session_params={
                             "notifications_disabled_categories": ["UNRECOGNIZED"]
                         },

--- a/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
+++ b/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
@@ -202,35 +202,7 @@ def test_neo4j_graph_init_with_empty_credentials() -> None:
         Neo4jGraph(
             url="bolt://localhost:7687", username="", password="", refresh_schema=False
         )
-        mock_driver.assert_called_with(
-            "bolt://localhost:7687", auth=None, notifications_min_severity="OFF"
-        )
-
-
-def test_neo4j_graph_init_notification_filtering_err() -> None:
-    """Test the __init__ method when notification filtering is disabled."""
-    with patch("neo4j.GraphDatabase.driver", autospec=True) as mock_driver:
-        mock_driver_instance = MagicMock()
-        mock_driver.return_value = mock_driver_instance
-        err = ConfigurationError("Notification filtering is not supported")
-        mock_driver_instance.verify_connectivity.side_effect = [err, None]
-        Neo4jGraph(
-            url="bolt://localhost:7687",
-            username="username",
-            password="password",
-            refresh_schema=False,
-        )
-        mock_driver.assert_any_call(
-            "bolt://localhost:7687",
-            auth=("username", "password"),
-            notifications_min_severity="OFF",
-        )
-        # The first call verify_connectivity should fail causing the driver to be
-        # recreated without the notifications_min_severity parameter
-        mock_driver.assert_any_call(
-            "bolt://localhost:7687",
-            auth=("username", "password"),
-        )
+        mock_driver.assert_called_with("bolt://localhost:7687", auth=None)
 
 
 def test_neo4j_graph_init_driver_config_err() -> None:


### PR DESCRIPTION
# Description

This PR fixes a few issues with the enhanced schema function of the `Neo4jGraph` class:
- Updates the `schema_counts` query to use the `apoc.meta.graph` procedure rather than the `apoc.meta.graphSample` procedure, which isn't as accurate.
- Removes the previously added default setting suppressing all warnings from the Neo4j driver.
- Adds `session_params` parameter to the `query` method of `Neo4jGraph` allowing for the passing of session specific parameters to the Neo4j driver.
- Updates the `Neo4jGraph.query` call used to get the enhanced schema so that specific warnings raised by this call are suppressed.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Medium

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

## Checklist

- [X] Unit tests updated
- [ ] Integration tests updated
- [X] CHANGELOG.md updated
