### PR TITLE
Makes GraphStore a Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Made the `source` parameter of `GraphDocument` optional and updated related methods to support this.
 - Suppressed AggregationSkippedNull warnings raised by the Neo4j driver in the Neo4jGraph class when fetching the enhanced_schema.
+- Updated `GraphStore` to be a Protocol, enabling compatibility with `GraphCypherQAChain` without requiring inheritance.
 
 ### Fixed
 

--- a/libs/neo4j/langchain_neo4j/graphs/graph_store.py
+++ b/libs/neo4j/langchain_neo4j/graphs/graph_store.py
@@ -1,37 +1,32 @@
-from abc import abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Protocol, runtime_checkable
 
 from langchain_neo4j.graphs.graph_document import GraphDocument
 
 
-class GraphStore:
+@runtime_checkable
+class GraphStore(Protocol):
     """Abstract class for graph operations."""
 
     @property
-    @abstractmethod
     def get_schema(self) -> str:
         """Return the schema of the Graph database"""
-        pass
+        ...
 
     @property
-    @abstractmethod
     def get_structured_schema(self) -> Dict[str, Any]:
         """Return the schema of the Graph database"""
-        pass
+        ...
 
-    @abstractmethod
     def query(self, query: str, params: dict = {}) -> List[Dict[str, Any]]:
         """Query the graph."""
-        pass
+        ...
 
-    @abstractmethod
     def refresh_schema(self) -> None:
         """Refresh the graph schema information."""
         pass
 
-    @abstractmethod
     def add_graph_documents(
         self, graph_documents: List[GraphDocument], include_source: bool = False
     ) -> None:
         """Take GraphDocument as input as uses it to construct a graph."""
-        pass
+        ...

--- a/libs/neo4j/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/neo4j/tests/unit_tests/chains/test_graph_qa.py
@@ -37,7 +37,7 @@ from langchain_neo4j.graphs.graph_store import GraphStore
 from tests.llms.fake_llm import FakeLLM
 
 
-class FakeGraphStore(GraphStore):
+class FakeGraphStore:
     @property
     def get_schema(self) -> str:
         """Returns the schema of the Graph database"""
@@ -61,6 +61,12 @@ class FakeGraphStore(GraphStore):
     ) -> None:
         """Take GraphDocument as input as uses it to construct a graph."""
         pass
+
+
+def test_graph_store() -> None:
+    """Tests that FakeGraphStore satisfies the GraphStore protocol requirements."""
+    graph = FakeGraphStore()
+    assert isinstance(graph, GraphStore)
 
 
 def test_graph_cypher_qa_chain_prompt_selection_1() -> None:


### PR DESCRIPTION
# Description

Previously, the `GraphStore` abstract base class lived in the LangChain Community package, allowing other graph DB vendors to inherit from it and build integrations for LangChain. We have now moved this class to the LangChain Neo4j package. We also require the `graph` passed to the `GraphCypherQAChain` to be a `GraphStore`. This means that other graph DB vendors must now inherit from the `GraphStore` class in the LangChain Neo4j package in order to be compatible with the `GraphCypherQAChain`.

This PR changes the `GraphStore` class to a [Protocol](https://mypy.readthedocs.io/en/stable/protocols.html), which allows other graph integrations to work with the `GraphCypherQAChain` without the explicit need to inherit from the `GraphStore` class in the LangChain Neo4j package.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

## Checklist

- [x] Unit tests updated
- [ ] Integration tests updated
- [x] CHANGELOG.md updated
