### PR TITLE
Added missing lucene special char to remove_lucene_chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - Resolved syntax errors in GraphCypherQAChain by ensuring node labels with spaces are correctly quoted in Cypher queries.
+- Added missing Lucene special character '/' to the list of characters escaped in `remove_lucene_chars`.
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Changed
 
 - Made the `source` parameter of `GraphDocument` optional and updated related methods to support this.
-- Suppressed AggregationSkippedNull warnings raised by the Neo4j driver in the Neo4jGraph class when fetching the enhanced_schema.
+- Suppressed AggregationSkippedNull warnings raised by the Neo4j driver in the `Neo4jGraph` class when fetching the enhanced_schema.
+- Modified the `Neo4jGraph` class's enhanced schema Cypher query to utilize the apoc.meta.graph procedure instead of apoc.meta.graphSample.
 - Updated `GraphStore` to be a Protocol, enabling compatibility with `GraphCypherQAChain` without requiring inheritance.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixed
 
-- Resolved syntax errors in GraphCypherQAChain by ensuring node labels with spaces are correctly quoted in Cypher queries.
+- Resolved syntax errors in `GraphCypherQAChain` by ensuring node labels with spaces are correctly quoted in Cypher queries.
 - Added missing Lucene special character '/' to the list of characters escaped in `remove_lucene_chars`.
 
 ## 0.2.0

--- a/libs/neo4j/langchain_neo4j/graphs/graph_store.py
+++ b/libs/neo4j/langchain_neo4j/graphs/graph_store.py
@@ -23,7 +23,7 @@ class GraphStore(Protocol):
 
     def refresh_schema(self) -> None:
         """Refresh the graph schema information."""
-        pass
+        ...
 
     def add_graph_documents(
         self, graph_documents: List[GraphDocument], include_source: bool = False

--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -160,6 +160,7 @@ def remove_lucene_chars(text: str) -> str:
         "?",
         ":",
         "\\",
+        "/",
     ]
     for char in special_chars:
         if char in text:

--- a/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
+++ b/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
@@ -179,6 +179,10 @@ def test_escaping_lucene() -> None:
         remove_lucene_chars("It is the end of the world. Take shelter~")
         == "It is the end of the world. Take shelter"
     )
+    assert (
+        remove_lucene_chars("It is the end of the world. Take shelter/")
+        == "It is the end of the world. Take shelter"
+    )
 
 
 def test_converting_to_yaml() -> None:


### PR DESCRIPTION
# Description

Adds the `/` character to the list of characters to be escaped before sending a query to Apache Lucene.

See [list of special characters](https://lucene.apache.org/core/10_1_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#escaping-special-characters-heading)

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

## Checklist

- [X] Unit tests updated
- [ ] Integration tests updated
- [X] CHANGELOG.md updated
