### PR TITLE
remove white space from Node labels because cypher queries generated …

### DIFF
--- a/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
+++ b/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
@@ -290,6 +290,8 @@ def _format_schema(schema: Dict, is_enhanced: bool) -> str:
 def _remove_backticks(text: str) -> str:
     return text.replace("`", "")
 
+def _replace_space(text: str) -> str:
+    return text.replace(" ","_")
 
 class Neo4jGraph(GraphStore):
     """Neo4j database wrapper for various graph operations.
@@ -689,7 +691,7 @@ class Neo4jGraph(GraphStore):
                     "data": [
                         {
                             "source": el.source.id,
-                            "source_label": _remove_backticks(el.source.type),
+                            "source_label": _replace_space(_remove_backticks(el.source.type)),
                             "target": el.target.id,
                             "target_label": _remove_backticks(el.target.type),
                             "type": _remove_backticks(


### PR DESCRIPTION

# Description

> **Note**
>
> Replaced white space in Node labels to underscores while adding the graph documents to database
>Cypher queries generated by GraphCypherQAChain is invalid if the label has white space in them.
>After replacing them with underscores, the queries generated for a user question became valid and is much more useful for public use cases.

## Type of Change

- [x] Bug fix


## Complexity


> Low

## How Has This Been Tested?


- [x] Manual tests


