### PR TITLE
Refactors GraphCypherQAChain with Neo4j GraphRAG code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Introduced a `delete_session_node` parameter to the `clear` method in `Neo4jChatMessageHistory` for optional deletion of the `Session` node.
+- Updates the `GraphCypherQAChain` to use the same schema format as `Neo4jGraph`.
 
 ## 0.3.0
 

--- a/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
+++ b/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
@@ -202,10 +202,11 @@ def test_exclude_types(neo4j_credentials: Neo4jCredentials) -> None:
         allow_dangerous_requests=True,
     )
     expected_schema = (
-        "Node properties are the following:\n"
-        "Actor {name: STRING},Movie {title: STRING}\n"
-        "Relationship properties are the following:\n\n"
-        "The relationships are the following:\n"
+        "Node properties:\n"
+        "Actor {name: STRING}\n"
+        "Movie {title: STRING}\n"
+        "Relationship properties:\n\n"
+        "The relationships:\n"
         "(:Actor)-[:ACTED_IN]->(:Movie)"
     )
     assert chain.graph_schema == expected_schema
@@ -234,10 +235,11 @@ def test_include_types(neo4j_credentials: Neo4jCredentials) -> None:
         allow_dangerous_requests=True,
     )
     expected_schema = (
-        "Node properties are the following:\n"
-        "Actor {name: STRING},Movie {title: STRING}\n"
-        "Relationship properties are the following:\n\n"
-        "The relationships are the following:\n"
+        "Node properties:\n"
+        "Actor {name: STRING}\n"
+        "Movie {title: STRING}\n"
+        "Relationship properties:\n\n"
+        "The relationships:\n"
         "(:Actor)-[:ACTED_IN]->(:Movie)"
     )
 
@@ -267,9 +269,9 @@ def test_include_types2(neo4j_credentials: Neo4jCredentials) -> None:
         allow_dangerous_requests=True,
     )
     expected_schema = (
-        "Node properties are the following:\n"
+        "Node properties:\n"
         "Movie {title: STRING}\n"
-        "Relationship properties are the following:\n\n"
-        "The relationships are the following:\n"
+        "Relationship properties:\n\n"
+        "The relationships:\n"
     )
     assert chain.graph_schema == expected_schema


### PR DESCRIPTION
# Description

- Removes the `extract_cypher` function and associated tests and replaces it with the `extract_cypher` function from the Neo4j GraphRAG package.
- Updates the `GraphCypherQAChain` to use the same schema format as `Neo4jGraph`.
- Updates the `construct_schema` function used by the `GraphCypherQAChain` to use schema creation functions from the Neo4jGraph GraphRAG package.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

## Checklist

- [X] Unit tests updated
- [X] Integration tests updated
- [x] CHANGELOG.md updated
