### PR TITLE
updated example generation code

### DIFF
--- a/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
+++ b/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
@@ -242,7 +242,7 @@ def _format_schema(schema: Dict, is_enhanced: bool) -> str:
                         example = f'Min: {prop["min"]}, Max: {prop["max"]}'
                     else:  # return a single value
                         example = (
-                            f'Example: "{prop["values"][0]}"' if prop["values"] else ""
+                            f'Example: "{prop["values"][0]}"' if "values" in prop else ""
                         )
                 elif prop["type"] == "LIST":
                     # Skip embeddings


### PR DESCRIPTION
if some of the node properties doesn't have ```values``` attribute, code start throwing error. update the to check if ```values``` attribute exist