### PR TITLE
Removes unneeded ImportErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Next
 
+### Changed
+
+- Renamed the `type` property to `role` on `Message` nodes in `Neo4jChatMessageHistory`.
+
+### Added
+
+- Introduced a `delete_session_node` parameter to the `clear` method in `Neo4jChatMessageHistory` for optional deletion of the `Session` node.
+
 ## 0.3.0
 
 ### Added

--- a/libs/neo4j/langchain_neo4j/chat_message_histories/neo4j.py
+++ b/libs/neo4j/langchain_neo4j/chat_message_histories/neo4j.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Union
 
+import neo4j
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import BaseMessage, messages_from_dict
 from langchain_core.utils import get_from_dict_or_env
@@ -29,14 +30,6 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
         *,
         graph: Optional[Neo4jGraph] = None,
     ):
-        try:
-            import neo4j
-        except ImportError:
-            raise ImportError(
-                "Could not import neo4j python package. "
-                "Please install it with `pip install neo4j`."
-            )
-
         # Make sure session id is not null
         if not session_id:
             raise ValueError("Please ensure that the session_id parameter is provided")

--- a/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
+++ b/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
@@ -1,6 +1,7 @@
 from hashlib import md5
 from typing import Any, Dict, List, Optional, Type
 
+import neo4j
 from langchain_core.utils import get_from_dict_or_env
 
 from langchain_neo4j.graphs.graph_document import GraphDocument
@@ -337,13 +338,6 @@ class Neo4jGraph(GraphStore):
         enhanced_schema: bool = False,
     ) -> None:
         """Create a new Neo4j graph wrapper instance."""
-        try:
-            import neo4j
-        except ImportError:
-            raise ImportError(
-                "Could not import neo4j python package. "
-                "Please install it with `pip install neo4j`."
-            )
 
         url = get_from_dict_or_env({"url": url}, "url", "NEO4J_URI")
         # if username and password are "", assume Neo4j auth is disabled

--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -15,6 +15,7 @@ from typing import (
     Type,
 )
 
+import neo4j
 import numpy as np
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
@@ -514,14 +515,6 @@ class Neo4jVector(VectorStore):
         graph: Optional[Neo4jGraph] = None,
         embedding_dimension: Optional[int] = None,
     ) -> None:
-        try:
-            import neo4j
-        except ImportError:
-            raise ImportError(
-                "Could not import neo4j python package. "
-                "Please install it with `pip install neo4j`."
-            )
-
         # Allow only cosine and euclidean distance strategies
         if distance_strategy not in [
             DistanceStrategy.EUCLIDEAN_DISTANCE,

--- a/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
+++ b/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
@@ -1,6 +1,6 @@
 """Test Graph Database Chain."""
 
-import os
+from typing import Dict
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,45 +10,14 @@ from langchain_neo4j.chains.graph_qa.cypher import GraphCypherQAChain
 from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
 from tests.llms.fake_llm import FakeLLM
 
-url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-username = os.environ.get("NEO4J_USERNAME", "neo4j")
-password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_connect_neo4j() -> None:
-    """Test that Neo4j database is correctly instantiated and connected."""
-    graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
-    )
-
-    output = graph.query('RETURN "test" AS output')
-    expected_output = [{"output": "test"}]
-    assert output == expected_output
-
-
-@pytest.mark.usefixtures("clear_neo4j_database")
-def test_connect_neo4j_env() -> None:
-    """Test that Neo4j database environment variables."""
-    os.environ["NEO4J_URI"] = url
-    os.environ["NEO4J_USERNAME"] = username
-    os.environ["NEO4J_PASSWORD"] = password
-    graph = Neo4jGraph()
-
-    output = graph.query('RETURN "test" AS output')
-    expected_output = [{"output": "test"}]
-    assert output == expected_output
-
-
-@pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_generating_run() -> None:
+def test_cypher_generating_run(neo4j_credentials: Dict[str, str]) -> None:
     """Test that Cypher statement is correctly generated and executed."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Create two nodes and a relationship
     graph.query(
@@ -78,13 +47,13 @@ def test_cypher_generating_run() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_top_k() -> None:
+def test_cypher_top_k(neo4j_credentials: Dict[str, str]) -> None:
     """Test top_k parameter correctly limits the number of results in the context."""
     TOP_K = 1
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -115,12 +84,12 @@ def test_cypher_top_k() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_intermediate_steps() -> None:
+def test_cypher_intermediate_steps(neo4j_credentials: Dict[str, str]) -> None:
     """Test the returning of the intermediate steps."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -159,12 +128,12 @@ def test_cypher_intermediate_steps() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_return_direct() -> None:
+def test_cypher_return_direct(neo4j_credentials: Dict[str, str]) -> None:
     """Test that chain returns direct results."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -194,12 +163,12 @@ def test_cypher_return_direct() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_function_response() -> None:
+def test_function_response(neo4j_credentials: Dict[str, str]) -> None:
     """Test returning a function response."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -231,12 +200,12 @@ def test_function_response() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_exclude_types() -> None:
+def test_exclude_types(neo4j_credentials: Dict[str, str]) -> None:
     """Test exclude types from schema."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -267,12 +236,12 @@ def test_exclude_types() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_include_types() -> None:
+def test_include_types(neo4j_credentials: Dict[str, str]) -> None:
     """Test include types from schema."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -304,12 +273,12 @@ def test_include_types() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_include_types2() -> None:
+def test_include_types2(neo4j_credentials: Dict[str, str]) -> None:
     """Test include types from schema."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")

--- a/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
+++ b/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
@@ -1,6 +1,5 @@
 """Test Graph Database Chain."""
 
-from typing import Dict
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,17 +7,14 @@ from langchain_core.language_models import BaseLanguageModel
 
 from langchain_neo4j.chains.graph_qa.cypher import GraphCypherQAChain
 from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
+from tests.integration_tests.utils import Neo4jCredentials
 from tests.llms.fake_llm import FakeLLM
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_generating_run(neo4j_credentials: Dict[str, str]) -> None:
+def test_cypher_generating_run(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that Cypher statement is correctly generated and executed."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Create two nodes and a relationship
     graph.query(
         "CREATE (a:Actor {name:'Bruce Willis'})"
@@ -47,14 +43,10 @@ def test_cypher_generating_run(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_top_k(neo4j_credentials: Dict[str, str]) -> None:
+def test_cypher_top_k(neo4j_credentials: Neo4jCredentials) -> None:
     """Test top_k parameter correctly limits the number of results in the context."""
     TOP_K = 1
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -84,13 +76,9 @@ def test_cypher_top_k(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_intermediate_steps(neo4j_credentials: Dict[str, str]) -> None:
+def test_cypher_intermediate_steps(neo4j_credentials: Neo4jCredentials) -> None:
     """Test the returning of the intermediate steps."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -128,13 +116,9 @@ def test_cypher_intermediate_steps(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_return_direct(neo4j_credentials: Dict[str, str]) -> None:
+def test_cypher_return_direct(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that chain returns direct results."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -163,13 +147,9 @@ def test_cypher_return_direct(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_function_response(neo4j_credentials: Dict[str, str]) -> None:
+def test_function_response(neo4j_credentials: Neo4jCredentials) -> None:
     """Test returning a function response."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -200,13 +180,9 @@ def test_function_response(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_exclude_types(neo4j_credentials: Dict[str, str]) -> None:
+def test_exclude_types(neo4j_credentials: Neo4jCredentials) -> None:
     """Test exclude types from schema."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -236,13 +212,9 @@ def test_exclude_types(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_include_types(neo4j_credentials: Dict[str, str]) -> None:
+def test_include_types(neo4j_credentials: Neo4jCredentials) -> None:
     """Test include types from schema."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -273,13 +245,9 @@ def test_include_types(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_include_types2(neo4j_credentials: Dict[str, str]) -> None:
+def test_include_types2(neo4j_credentials: Neo4jCredentials) -> None:
     """Test include types from schema."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship

--- a/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
+++ b/libs/neo4j/tests/integration_tests/chains/test_graph_database.py
@@ -3,19 +3,21 @@
 import os
 from unittest.mock import MagicMock
 
+import pytest
 from langchain_core.language_models import BaseLanguageModel
 
 from langchain_neo4j.chains.graph_qa.cypher import GraphCypherQAChain
 from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
 from tests.llms.fake_llm import FakeLLM
 
+url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+username = os.environ.get("NEO4J_USERNAME", "neo4j")
+password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
 
+
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_connect_neo4j() -> None:
     """Test that Neo4j database is correctly instantiated and connected."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -27,11 +29,9 @@ def test_connect_neo4j() -> None:
     assert output == expected_output
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_connect_neo4j_env() -> None:
     """Test that Neo4j database environment variables."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
     os.environ["NEO4J_URI"] = url
     os.environ["NEO4J_USERNAME"] = username
     os.environ["NEO4J_PASSWORD"] = password
@@ -40,24 +40,16 @@ def test_connect_neo4j_env() -> None:
     output = graph.query('RETURN "test" AS output')
     expected_output = [{"output": "test"}]
     assert output == expected_output
-    del os.environ["NEO4J_URI"]
-    del os.environ["NEO4J_USERNAME"]
-    del os.environ["NEO4J_PASSWORD"]
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_cypher_generating_run() -> None:
     """Test that Cypher statement is correctly generated and executed."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     graph = Neo4jGraph(
         url=url,
         username=username,
         password=password,
     )
-    # Delete all nodes in the graph
-    graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
     graph.query(
         "CREATE (a:Actor {name:'Bruce Willis'})"
@@ -85,14 +77,10 @@ def test_cypher_generating_run() -> None:
     assert output == expected_output
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_cypher_top_k() -> None:
     """Test top_k parameter correctly limits the number of results in the context."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     TOP_K = 1
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -126,12 +114,9 @@ def test_cypher_top_k() -> None:
     assert len(output) == TOP_K
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_cypher_intermediate_steps() -> None:
     """Test the returning of the intermediate steps."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -173,12 +158,9 @@ def test_cypher_intermediate_steps() -> None:
     assert context == expected_context
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_cypher_return_direct() -> None:
     """Test that chain returns direct results."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -211,12 +193,9 @@ def test_cypher_return_direct() -> None:
     assert output == expected_output
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_function_response() -> None:
     """Test returning a function response."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -251,12 +230,9 @@ def test_function_response() -> None:
     assert output == expected_output
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_exclude_types() -> None:
     """Test exclude types from schema."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -290,12 +266,9 @@ def test_exclude_types() -> None:
     assert chain.graph_schema == expected_schema
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_include_types() -> None:
     """Test include types from schema."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -330,12 +303,9 @@ def test_include_types() -> None:
     assert chain.graph_schema == expected_schema
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_include_types2() -> None:
     """Test include types from schema."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
     graph = Neo4jGraph(
         url=url,
         username=username,

--- a/libs/neo4j/tests/integration_tests/chat_message_histories/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/chat_message_histories/test_neo4j.py
@@ -12,6 +12,7 @@ username = os.environ.get("NEO4J_USERNAME", "neo4j")
 password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_add_messages() -> None:
     """Basic testing: adding messages to the Neo4jChatMessageHistory."""
     os.environ["NEO4J_URI"] = url
@@ -62,6 +63,7 @@ def test_add_messages() -> None:
     del os.environ["NEO4J_PASSWORD"]
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_add_messages_graph_object() -> None:
     """Basic testing: Passing driver through graph object."""
     os.environ["NEO4J_URI"] = url
@@ -122,6 +124,7 @@ def test_invalid_credentials() -> None:
     )
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_message_history_clear_messages() -> None:
     message_history = Neo4jChatMessageHistory(
         session_id="123", url=url, username=username, password=password
@@ -144,6 +147,7 @@ def test_neo4j_message_history_clear_messages() -> None:
     assert list(results.records[0]["s"].labels) == ["Session"]
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_message_history_clear_session_and_messages() -> None:
     message_history = Neo4jChatMessageHistory(
         session_id="123", url=url, username=username, password=password

--- a/libs/neo4j/tests/integration_tests/chat_message_histories/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/chat_message_histories/test_neo4j.py
@@ -1,5 +1,6 @@
 import os
 import urllib.parse
+from typing import Dict
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
@@ -7,17 +8,10 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langchain_neo4j.chat_message_histories.neo4j import Neo4jChatMessageHistory
 from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
 
-url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-username = os.environ.get("NEO4J_USERNAME", "neo4j")
-password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_add_messages() -> None:
     """Basic testing: adding messages to the Neo4jChatMessageHistory."""
-    os.environ["NEO4J_URI"] = url
-    os.environ["NEO4J_USERNAME"] = username
-    os.environ["NEO4J_PASSWORD"] = password
     assert os.environ.get("NEO4J_URI") is not None
     assert os.environ.get("NEO4J_USERNAME") is not None
     assert os.environ.get("NEO4J_PASSWORD") is not None
@@ -58,22 +52,17 @@ def test_add_messages() -> None:
     assert len(message_store.messages) == 0
     assert len(message_store_another.messages) == 0
 
-    del os.environ["NEO4J_URI"]
-    del os.environ["NEO4J_USERNAME"]
-    del os.environ["NEO4J_PASSWORD"]
-
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_add_messages_graph_object() -> None:
+def test_add_messages_graph_object(neo4j_credentials: Dict[str, str]) -> None:
     """Basic testing: Passing driver through graph object."""
-    os.environ["NEO4J_URI"] = url
-    os.environ["NEO4J_USERNAME"] = username
-    os.environ["NEO4J_PASSWORD"] = password
-    assert os.environ.get("NEO4J_URI") is not None
-    assert os.environ.get("NEO4J_USERNAME") is not None
-    assert os.environ.get("NEO4J_PASSWORD") is not None
-    graph = Neo4jGraph()
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    )
     # rewrite env for testing
+    old_username = os.environ["NEO4J_USERNAME"]
     os.environ["NEO4J_USERNAME"] = "foo"
     message_store = Neo4jChatMessageHistory("23334", graph=graph)
     message_store.clear()
@@ -82,16 +71,13 @@ def test_add_messages_graph_object() -> None:
     message_store.add_ai_message("Hi Guys!")
     # Now check if the messages are stored in the database correctly
     assert len(message_store.messages) == 2
-
-    del os.environ["NEO4J_URI"]
-    del os.environ["NEO4J_USERNAME"]
-    del os.environ["NEO4J_PASSWORD"]
+    os.environ["NEO4J_USERNAME"] = old_username
 
 
-def test_invalid_url() -> None:
+def test_invalid_url(neo4j_credentials: Dict[str, str]) -> None:
     """Test initializing with invalid credentials raises ValueError."""
     # Parse the original URL
-    parsed_url = urllib.parse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(neo4j_credentials["url"])
     # Increment the port number by 1 and wrap around if necessary
     original_port = parsed_url.port or 7687
     new_port = (original_port + 1) % 65535 or 1
@@ -104,18 +90,18 @@ def test_invalid_url() -> None:
         Neo4jChatMessageHistory(
             "test_session",
             url=new_url,
-            username=username,
-            password=password,
+            username=neo4j_credentials["username"],
+            password=neo4j_credentials["password"],
         )
     assert "Please ensure that the url is correct" in str(exc_info.value)
 
 
-def test_invalid_credentials() -> None:
+def test_invalid_credentials(neo4j_credentials: Dict[str, str]) -> None:
     """Test initializing with invalid credentials raises ValueError."""
     with pytest.raises(ValueError) as exc_info:
         Neo4jChatMessageHistory(
             "test_session",
-            url=url,
+            url=neo4j_credentials["url"],
             username="invalid_username",
             password="invalid_password",
         )
@@ -125,9 +111,12 @@ def test_invalid_credentials() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_message_history_clear_messages() -> None:
+def test_neo4j_message_history_clear_messages(neo4j_credentials: Dict[str, str]) -> None:
     message_history = Neo4jChatMessageHistory(
-        session_id="123", url=url, username=username, password=password
+        session_id="123",
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     message_history.add_messages(
         [
@@ -148,9 +137,14 @@ def test_neo4j_message_history_clear_messages() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_message_history_clear_session_and_messages() -> None:
+def test_neo4j_message_history_clear_session_and_messages(
+    neo4j_credentials: Dict[str, str]
+) -> None:
     message_history = Neo4jChatMessageHistory(
-        session_id="123", url=url, username=username, password=password
+        session_id="123",
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     message_history.add_messages(
         [

--- a/libs/neo4j/tests/integration_tests/chat_message_histories/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/chat_message_histories/test_neo4j.py
@@ -111,7 +111,9 @@ def test_invalid_credentials(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_message_history_clear_messages(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_message_history_clear_messages(
+    neo4j_credentials: Dict[str, str],
+) -> None:
     message_history = Neo4jChatMessageHistory(
         session_id="123",
         url=neo4j_credentials["url"],
@@ -138,7 +140,7 @@ def test_neo4j_message_history_clear_messages(neo4j_credentials: Dict[str, str])
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_message_history_clear_session_and_messages(
-    neo4j_credentials: Dict[str, str]
+    neo4j_credentials: Dict[str, str],
 ) -> None:
     message_history = Neo4jChatMessageHistory(
         session_id="123",

--- a/libs/neo4j/tests/integration_tests/chat_message_histories/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/chat_message_histories/test_neo4j.py
@@ -1,12 +1,12 @@
 import os
 import urllib.parse
-from typing import Dict
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
 from langchain_neo4j.chat_message_histories.neo4j import Neo4jChatMessageHistory
 from langchain_neo4j.graphs.neo4j_graph import Neo4jGraph
+from tests.integration_tests.utils import Neo4jCredentials
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
@@ -54,13 +54,9 @@ def test_add_messages() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_add_messages_graph_object(neo4j_credentials: Dict[str, str]) -> None:
+def test_add_messages_graph_object(neo4j_credentials: Neo4jCredentials) -> None:
     """Basic testing: Passing driver through graph object."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # rewrite env for testing
     old_username = os.environ["NEO4J_USERNAME"]
     os.environ["NEO4J_USERNAME"] = "foo"
@@ -74,7 +70,7 @@ def test_add_messages_graph_object(neo4j_credentials: Dict[str, str]) -> None:
     os.environ["NEO4J_USERNAME"] = old_username
 
 
-def test_invalid_url(neo4j_credentials: Dict[str, str]) -> None:
+def test_invalid_url(neo4j_credentials: Neo4jCredentials) -> None:
     """Test initializing with invalid credentials raises ValueError."""
     # Parse the original URL
     parsed_url = urllib.parse.urlparse(neo4j_credentials["url"])
@@ -96,7 +92,7 @@ def test_invalid_url(neo4j_credentials: Dict[str, str]) -> None:
     assert "Please ensure that the url is correct" in str(exc_info.value)
 
 
-def test_invalid_credentials(neo4j_credentials: Dict[str, str]) -> None:
+def test_invalid_credentials(neo4j_credentials: Neo4jCredentials) -> None:
     """Test initializing with invalid credentials raises ValueError."""
     with pytest.raises(ValueError) as exc_info:
         Neo4jChatMessageHistory(
@@ -112,14 +108,9 @@ def test_invalid_credentials(neo4j_credentials: Dict[str, str]) -> None:
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_message_history_clear_messages(
-    neo4j_credentials: Dict[str, str],
+    neo4j_credentials: Neo4jCredentials,
 ) -> None:
-    message_history = Neo4jChatMessageHistory(
-        session_id="123",
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    message_history = Neo4jChatMessageHistory(session_id="123", **neo4j_credentials)
     message_history.add_messages(
         [
             HumanMessage(content="You are a helpful assistant."),
@@ -140,14 +131,9 @@ def test_neo4j_message_history_clear_messages(
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_message_history_clear_session_and_messages(
-    neo4j_credentials: Dict[str, str],
+    neo4j_credentials: Neo4jCredentials,
 ) -> None:
-    message_history = Neo4jChatMessageHistory(
-        session_id="123",
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    message_history = Neo4jChatMessageHistory(session_id="123", **neo4j_credentials)
     message_history.add_messages(
         [
             HumanMessage(content="You are a helpful assistant."),

--- a/libs/neo4j/tests/integration_tests/conftest.py
+++ b/libs/neo4j/tests/integration_tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+
+import neo4j
+import pytest
+
+url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+username = os.environ.get("NEO4J_USERNAME", "neo4j")
+password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
+
+
+@pytest.fixture
+def clear_neo4j_database() -> None:
+    driver = neo4j.GraphDatabase.driver(url, auth=(username, password))
+    driver.execute_query("MATCH (n) DETACH DELETE n;")
+    driver.close()

--- a/libs/neo4j/tests/integration_tests/conftest.py
+++ b/libs/neo4j/tests/integration_tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict
 
 import neo4j
 import pytest
@@ -6,6 +7,9 @@ import pytest
 url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
 username = os.environ.get("NEO4J_USERNAME", "neo4j")
 password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
+os.environ["NEO4J_URI"] = url
+os.environ["NEO4J_USERNAME"] = username
+os.environ["NEO4J_PASSWORD"] = password
 
 
 @pytest.fixture
@@ -13,3 +17,12 @@ def clear_neo4j_database() -> None:
     driver = neo4j.GraphDatabase.driver(url, auth=(username, password))
     driver.execute_query("MATCH (n) DETACH DELETE n;")
     driver.close()
+
+
+@pytest.fixture(scope="session")
+def neo4j_credentials() -> Dict[str, str]:
+    return {
+        "url": url,
+        "username": username,
+        "password": password,
+    }

--- a/libs/neo4j/tests/integration_tests/conftest.py
+++ b/libs/neo4j/tests/integration_tests/conftest.py
@@ -1,8 +1,9 @@
 import os
-from typing import Dict
 
 import neo4j
 import pytest
+
+from tests.integration_tests.utils import Neo4jCredentials
 
 url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
 username = os.environ.get("NEO4J_USERNAME", "neo4j")
@@ -20,7 +21,7 @@ def clear_neo4j_database() -> None:
 
 
 @pytest.fixture(scope="session")
-def neo4j_credentials() -> Dict[str, str]:
+def neo4j_credentials() -> Neo4jCredentials:
     return {
         "url": url,
         "username": username,

--- a/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
@@ -1,5 +1,6 @@
 import os
 import urllib
+from typing import Dict
 
 import pytest
 from langchain_core.documents import Document
@@ -43,18 +44,40 @@ test_data_backticks = [
 ]
 
 
-url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-username = os.environ.get("NEO4J_USERNAME", "neo4j")
-password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
+@pytest.mark.usefixtures("clear_neo4j_database")
+def test_connect_neo4j(neo4j_credentials: Dict[str, str]) -> None:
+    """Test that Neo4j database is correctly instantiated and connected."""
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    )
+
+    output = graph.query('RETURN "test" AS output')
+    expected_output = [{"output": "test"}]
+    assert output == expected_output
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_return_correct_schema() -> None:
+def test_connect_neo4j_env() -> None:
+    """Test that Neo4j database environment variables."""
+    assert os.environ.get("NEO4J_URI") is not None
+    assert os.environ.get("NEO4J_USERNAME") is not None
+    assert os.environ.get("NEO4J_PASSWORD") is not None
+    graph = Neo4jGraph()
+
+    output = graph.query('RETURN "test" AS output')
+    expected_output = [{"output": "test"}]
+    assert output == expected_output
+
+
+@pytest.mark.usefixtures("clear_neo4j_database")
+def test_cypher_return_correct_schema(neo4j_credentials: Dict[str, str]) -> None:
     """Test that chain returns direct results."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
     )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -112,9 +135,14 @@ def test_cypher_return_correct_schema() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_timeout() -> None:
+def test_neo4j_timeout(neo4j_credentials: Dict[str, str]) -> None:
     """Test that neo4j uses the timeout correctly."""
-    graph = Neo4jGraph(url=url, username=username, password=password, timeout=0.1)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+        timeout=0.1,
+    )
     try:
         graph.query("UNWIND range(0,100000,1) AS i MERGE (:Foo {id:i})")
     except Exception as e:
@@ -126,9 +154,14 @@ def test_neo4j_timeout() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_sanitize_values() -> None:
+def test_neo4j_sanitize_values(neo4j_credentials: Dict[str, str]) -> None:
     """Test that lists with more than 128 elements are removed from the results."""
-    graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+        sanitize=True,
+    )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -148,9 +181,14 @@ def test_neo4j_sanitize_values() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_add_data() -> None:
+def test_neo4j_add_data(neo4j_credentials: Dict[str, str]) -> None:
     """Test that neo4j correctly import graph document."""
-    graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+        sanitize=True,
+    )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -166,9 +204,14 @@ def test_neo4j_add_data() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_add_data_source() -> None:
+def test_neo4j_add_data_source(neo4j_credentials: Dict[str, str]) -> None:
     """Test that neo4j correctly import graph document with source."""
-    graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+        sanitize=True,
+    )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -188,9 +231,14 @@ def test_neo4j_add_data_source() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_add_data_base() -> None:
+def test_neo4j_add_data_base(neo4j_credentials: Dict[str, str]) -> None:
     """Test that neo4j correctly import graph document with base_entity."""
-    graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+        sanitize=True,
+    )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -210,9 +258,14 @@ def test_neo4j_add_data_base() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_add_data_base_source() -> None:
+def test_neo4j_add_data_base_source(neo4j_credentials: Dict[str, str]) -> None:
     """Test that neo4j correctly import graph document with base_entity and source."""
-    graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+        sanitize=True,
+    )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -233,9 +286,14 @@ def test_neo4j_add_data_base_source() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_filtering_labels() -> None:
+def test_neo4j_filtering_labels(neo4j_credentials: Dict[str, str]) -> None:
     """Test that neo4j correctly filters excluded labels."""
-    graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+        sanitize=True,
+    )
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -256,22 +314,25 @@ def test_neo4j_filtering_labels() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_driver_config() -> None:
+def test_driver_config(neo4j_credentials: Dict[str, str]) -> None:
     """Test that neo4j works with driver config."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
         driver_config={"max_connection_pool_size": 1},
     )
     graph.query("RETURN 'foo'")
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_enhanced_schema() -> None:
+def test_enhanced_schema(neo4j_credentials: Dict[str, str]) -> None:
     """Test that neo4j works with driver config."""
     graph = Neo4jGraph(
-        url=url, username=username, password=password, enhanced_schema=True
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+        enhanced_schema=True,
     )
     graph.query("MATCH (n) DETACH DELETE n")
     graph.add_graph_documents(test_data)
@@ -313,12 +374,12 @@ def test_enhanced_schema() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_enhanced_schema_exception() -> None:
+def test_enhanced_schema_exception(neo4j_credentials: Dict[str, str]) -> None:
     """Test no error with weird schema."""
     graph = Neo4jGraph(
-        url=url,
-        username=username,
-        password=password,
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
         enhanced_schema=True,
         refresh_schema=False,
     )
@@ -353,9 +414,13 @@ def test_enhanced_schema_exception() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_backticks() -> None:
+def test_backticks(neo4j_credentials: Dict[str, str]) -> None:
     """Test that backticks are correctly removed."""
-    graph = Neo4jGraph(url=url, username=username, password=password)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    )
     graph.query("MATCH (n) DETACH DELETE n")
     graph.add_graph_documents(test_data_backticks)
     nodes = graph.query("MATCH (n) RETURN labels(n) AS labels ORDER BY n.id")
@@ -368,9 +433,13 @@ def test_backticks() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_context_manager() -> None:
+def test_neo4j_context_manager(neo4j_credentials: Dict[str, str]) -> None:
     """Test that Neo4jGraph works correctly with context manager."""
-    with Neo4jGraph(url=url, username=username, password=password) as graph:
+    with Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    ) as graph:
         # Test that the connection is working
         graph.query("RETURN 1 as n")
 
@@ -383,9 +452,13 @@ def test_neo4j_context_manager() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_explicit_close() -> None:
+def test_neo4j_explicit_close(neo4j_credentials: Dict[str, str]) -> None:
     """Test that Neo4jGraph can be explicitly closed."""
-    graph = Neo4jGraph(url=url, username=username, password=password)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    )
     # Test that the connection is working
     graph.query("RETURN 1 as n")
 
@@ -401,9 +474,13 @@ def test_neo4j_explicit_close() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_error_after_close() -> None:
+def test_neo4j_error_after_close(neo4j_credentials: Dict[str, str]) -> None:
     """Test that Neo4jGraph operations raise proper errors after closing."""
-    graph = Neo4jGraph(url=url, username=username, password=password)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    )
     graph.query("RETURN 1")  # Should work
     graph.close()
 
@@ -430,10 +507,18 @@ def test_neo4j_error_after_close() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_concurrent_connections() -> None:
+def test_neo4j_concurrent_connections(neo4j_credentials: Dict[str, str]) -> None:
     """Test that multiple Neo4jGraph instances can be used independently."""
-    graph1 = Neo4jGraph(url=url, username=username, password=password)
-    graph2 = Neo4jGraph(url=url, username=username, password=password)
+    graph1 = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    )
+    graph2 = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    )
 
     # Both connections should work independently
     assert graph1.query("RETURN 1 as n") == [{"n": 1}]
@@ -452,10 +537,18 @@ def test_neo4j_concurrent_connections() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_nested_context_managers() -> None:
+def test_neo4j_nested_context_managers(neo4j_credentials: Dict[str, str]) -> None:
     """Test that nested context managers work correctly."""
-    with Neo4jGraph(url=url, username=username, password=password) as graph1:
-        with Neo4jGraph(url=url, username=username, password=password) as graph2:
+    with Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    ) as graph1:
+        with Neo4jGraph(
+            url=neo4j_credentials["url"],
+            username=neo4j_credentials["username"],
+            password=neo4j_credentials["password"],
+        ) as graph2:
             # Both connections should work
             assert graph1.query("RETURN 1 as n") == [{"n": 1}]
             assert graph2.query("RETURN 2 as n") == [{"n": 2}]
@@ -482,19 +575,23 @@ def test_neo4j_nested_context_managers() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_multiple_close() -> None:
+def test_neo4j_multiple_close(neo4j_credentials: Dict[str, str]) -> None:
     """Test that Neo4jGraph can be closed multiple times without error."""
-    graph = Neo4jGraph(url=url, username=username, password=password)
+    graph = Neo4jGraph(
+        url=neo4j_credentials["url"],
+        username=neo4j_credentials["username"],
+        password=neo4j_credentials["password"],
+    )
     # Test that multiple closes don't raise errors
     graph.close()
     graph.close()  # This should not raise an error
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_invalid_url() -> None:
+def test_invalid_url(neo4j_credentials: Dict[str, str]) -> None:
     """Test initializing with invalid credentials raises ValueError."""
     # Parse the original URL
-    parsed_url = urllib.parse.urlparse(url)
+    parsed_url = urllib.parse.urlparse(neo4j_credentials["url"])
     # Increment the port number by 1 and wrap around if necessary
     original_port = parsed_url.port or 7687
     new_port = (original_port + 1) % 65535 or 1
@@ -506,21 +603,19 @@ def test_invalid_url() -> None:
     with pytest.raises(ValueError) as exc_info:
         Neo4jGraph(
             url=new_url,
-            username=username,
-            password=password,
+            username=neo4j_credentials["username"],
+            password=neo4j_credentials["password"],
         )
     assert "Please ensure that the url is correct" in str(exc_info.value)
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_invalid_credentials() -> None:
+def test_invalid_credentials(neo4j_credentials: Dict[str, str]) -> None:
     """Test initializing with invalid credentials raises ValueError."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    assert url is not None
 
     with pytest.raises(ValueError) as exc_info:
         Neo4jGraph(
-            url=url,
+            url=neo4j_credentials["url"],
             username="invalid_username",
             password="invalid_password",
         )

--- a/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
@@ -43,15 +43,14 @@ test_data_backticks = [
 ]
 
 
+url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
+username = os.environ.get("NEO4J_USERNAME", "neo4j")
+password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
+
+
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_cypher_return_correct_schema() -> None:
     """Test that chain returns direct results."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -112,15 +111,9 @@ def test_cypher_return_correct_schema() -> None:
     )
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_timeout() -> None:
     """Test that neo4j uses the timeout correctly."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password, timeout=0.1)
     try:
         graph.query("UNWIND range(0,100000,1) AS i MERGE (:Foo {id:i})")
@@ -132,15 +125,9 @@ def test_neo4j_timeout() -> None:
         )
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_sanitize_values() -> None:
     """Test that lists with more than 128 elements are removed from the results."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -160,15 +147,9 @@ def test_neo4j_sanitize_values() -> None:
     assert output == [{}]
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_add_data() -> None:
     """Test that neo4j correctly import graph document."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -184,15 +165,9 @@ def test_neo4j_add_data() -> None:
     assert graph.structured_schema["metadata"]["constraint"] == []
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_add_data_source() -> None:
     """Test that neo4j correctly import graph document with source."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -212,15 +187,9 @@ def test_neo4j_add_data_source() -> None:
     assert graph.structured_schema["metadata"]["constraint"] == []
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_add_data_base() -> None:
     """Test that neo4j correctly import graph document with base_entity."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -240,15 +209,9 @@ def test_neo4j_add_data_base() -> None:
     assert graph.structured_schema["metadata"]["constraint"] != []
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_add_data_base_source() -> None:
     """Test that neo4j correctly import graph document with base_entity and source."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -269,15 +232,9 @@ def test_neo4j_add_data_base_source() -> None:
     assert graph.structured_schema["metadata"]["constraint"] != []
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_filtering_labels() -> None:
     """Test that neo4j correctly filters excluded labels."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password, sanitize=True)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
@@ -298,15 +255,9 @@ def test_neo4j_filtering_labels() -> None:
     assert graph.structured_schema["relationships"] == []
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_driver_config() -> None:
     """Test that neo4j works with driver config."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -316,15 +267,9 @@ def test_driver_config() -> None:
     graph.query("RETURN 'foo'")
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_enhanced_schema() -> None:
     """Test that neo4j works with driver config."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(
         url=url, username=username, password=password, enhanced_schema=True
     )
@@ -367,15 +312,9 @@ def test_enhanced_schema() -> None:
     assert graph.structured_schema == expected_output
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_enhanced_schema_exception() -> None:
     """Test no error with weird schema."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(
         url=url,
         username=username,
@@ -413,15 +352,9 @@ def test_enhanced_schema_exception() -> None:
     assert graph.structured_schema == expected_output
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_backticks() -> None:
     """Test that backticks are correctly removed."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password)
     graph.query("MATCH (n) DETACH DELETE n")
     graph.add_graph_documents(test_data_backticks)
@@ -434,15 +367,9 @@ def test_backticks() -> None:
     assert rels == expected_rels
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_context_manager() -> None:
     """Test that Neo4jGraph works correctly with context manager."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     with Neo4jGraph(url=url, username=username, password=password) as graph:
         # Test that the connection is working
         graph.query("RETURN 1 as n")
@@ -455,15 +382,9 @@ def test_neo4j_context_manager() -> None:
         pass
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_explicit_close() -> None:
     """Test that Neo4jGraph can be explicitly closed."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password)
     # Test that the connection is working
     graph.query("RETURN 1 as n")
@@ -479,15 +400,9 @@ def test_neo4j_explicit_close() -> None:
         pass
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_error_after_close() -> None:
     """Test that Neo4jGraph operations raise proper errors after closing."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password)
     graph.query("RETURN 1")  # Should work
     graph.close()
@@ -514,15 +429,9 @@ def test_neo4j_error_after_close() -> None:
         assert "connection has been closed" in str(e)
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_concurrent_connections() -> None:
     """Test that multiple Neo4jGraph instances can be used independently."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph1 = Neo4jGraph(url=url, username=username, password=password)
     graph2 = Neo4jGraph(url=url, username=username, password=password)
 
@@ -542,15 +451,9 @@ def test_neo4j_concurrent_connections() -> None:
     graph2.close()
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_nested_context_managers() -> None:
     """Test that nested context managers work correctly."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     with Neo4jGraph(url=url, username=username, password=password) as graph1:
         with Neo4jGraph(url=url, username=username, password=password) as graph2:
             # Both connections should work
@@ -578,30 +481,18 @@ def test_neo4j_nested_context_managers() -> None:
         pass
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4j_multiple_close() -> None:
     """Test that Neo4jGraph can be closed multiple times without error."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     graph = Neo4jGraph(url=url, username=username, password=password)
     # Test that multiple closes don't raise errors
     graph.close()
     graph.close()  # This should not raise an error
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_invalid_url() -> None:
     """Test initializing with invalid credentials raises ValueError."""
-    url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
-    username = os.environ.get("NEO4J_USERNAME", "neo4j")
-    password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
-    assert url is not None
-    assert username is not None
-    assert password is not None
-
     # Parse the original URL
     parsed_url = urllib.parse.urlparse(url)
     # Increment the port number by 1 and wrap around if necessary
@@ -621,6 +512,7 @@ def test_invalid_url() -> None:
     assert "Please ensure that the url is correct" in str(exc_info.value)
 
 
+@pytest.mark.usefixtures("clear_neo4j_database")
 def test_invalid_credentials() -> None:
     """Test initializing with invalid credentials raises ValueError."""
     url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")

--- a/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
@@ -1,6 +1,5 @@
 import os
 import urllib
-from typing import Dict
 
 import pytest
 from langchain_core.documents import Document
@@ -13,6 +12,7 @@ from langchain_neo4j.graphs.neo4j_graph import (
     rel_properties_query,
     rel_query,
 )
+from tests.integration_tests.utils import Neo4jCredentials
 
 test_data = [
     GraphDocument(
@@ -45,13 +45,9 @@ test_data_backticks = [
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_connect_neo4j(neo4j_credentials: Dict[str, str]) -> None:
+def test_connect_neo4j(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that Neo4j database is correctly instantiated and connected."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
 
     output = graph.query('RETURN "test" AS output')
     expected_output = [{"output": "test"}]
@@ -72,13 +68,9 @@ def test_connect_neo4j_env() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_cypher_return_correct_schema(neo4j_credentials: Dict[str, str]) -> None:
+def test_cypher_return_correct_schema(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that chain returns direct results."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -135,14 +127,9 @@ def test_cypher_return_correct_schema(neo4j_credentials: Dict[str, str]) -> None
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_timeout(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_timeout(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that neo4j uses the timeout correctly."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        timeout=0.1,
-    )
+    graph = Neo4jGraph(timeout=0.1, **neo4j_credentials)
     try:
         graph.query("UNWIND range(0,100000,1) AS i MERGE (:Foo {id:i})")
     except Exception as e:
@@ -154,14 +141,9 @@ def test_neo4j_timeout(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_sanitize_values(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_sanitize_values(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that lists with more than 128 elements are removed from the results."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        sanitize=True,
-    )
+    graph = Neo4jGraph(sanitize=True, **neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Create two nodes and a relationship
@@ -181,14 +163,9 @@ def test_neo4j_sanitize_values(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_add_data(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_add_data(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that neo4j correctly import graph document."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        sanitize=True,
-    )
+    graph = Neo4jGraph(sanitize=True, **neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -204,14 +181,9 @@ def test_neo4j_add_data(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_add_data_source(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_add_data_source(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that neo4j correctly import graph document with source."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        sanitize=True,
-    )
+    graph = Neo4jGraph(sanitize=True, **neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -231,14 +203,9 @@ def test_neo4j_add_data_source(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_add_data_base(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_add_data_base(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that neo4j correctly import graph document with base_entity."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        sanitize=True,
-    )
+    graph = Neo4jGraph(sanitize=True, **neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -258,14 +225,9 @@ def test_neo4j_add_data_base(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_add_data_base_source(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_add_data_base_source(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that neo4j correctly import graph document with base_entity and source."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        sanitize=True,
-    )
+    graph = Neo4jGraph(sanitize=True, **neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -286,14 +248,9 @@ def test_neo4j_add_data_base_source(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_filtering_labels(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_filtering_labels(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that neo4j correctly filters excluded labels."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        sanitize=True,
-    )
+    graph = Neo4jGraph(sanitize=True, **neo4j_credentials)
     # Delete all nodes in the graph
     graph.query("MATCH (n) DETACH DELETE n")
     # Remove all constraints
@@ -314,26 +271,18 @@ def test_neo4j_filtering_labels(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_driver_config(neo4j_credentials: Dict[str, str]) -> None:
+def test_driver_config(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that neo4j works with driver config."""
     graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        driver_config={"max_connection_pool_size": 1},
+        driver_config={"max_connection_pool_size": 1}, **neo4j_credentials
     )
     graph.query("RETURN 'foo'")
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_enhanced_schema(neo4j_credentials: Dict[str, str]) -> None:
+def test_enhanced_schema(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that neo4j works with driver config."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        enhanced_schema=True,
-    )
+    graph = Neo4jGraph(enhanced_schema=True, **neo4j_credentials)
     graph.query("MATCH (n) DETACH DELETE n")
     graph.add_graph_documents(test_data)
     graph.refresh_schema()
@@ -374,15 +323,9 @@ def test_enhanced_schema(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_enhanced_schema_exception(neo4j_credentials: Dict[str, str]) -> None:
+def test_enhanced_schema_exception(neo4j_credentials: Neo4jCredentials) -> None:
     """Test no error with weird schema."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-        enhanced_schema=True,
-        refresh_schema=False,
-    )
+    graph = Neo4jGraph(enhanced_schema=True, refresh_schema=False, **neo4j_credentials)
     graph.query("MATCH (n) DETACH DELETE n")
     graph.query(
         "CREATE (:Node {foo: 'bar'}), (:Node {foo: 1}), (:Node {foo: [1,2]}), "
@@ -414,13 +357,9 @@ def test_enhanced_schema_exception(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_backticks(neo4j_credentials: Dict[str, str]) -> None:
+def test_backticks(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that backticks are correctly removed."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     graph.query("MATCH (n) DETACH DELETE n")
     graph.add_graph_documents(test_data_backticks)
     nodes = graph.query("MATCH (n) RETURN labels(n) AS labels ORDER BY n.id")
@@ -433,13 +372,9 @@ def test_backticks(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_context_manager(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_context_manager(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that Neo4jGraph works correctly with context manager."""
-    with Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    ) as graph:
+    with Neo4jGraph(**neo4j_credentials) as graph:
         # Test that the connection is working
         graph.query("RETURN 1 as n")
 
@@ -452,13 +387,9 @@ def test_neo4j_context_manager(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_explicit_close(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_explicit_close(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that Neo4jGraph can be explicitly closed."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Test that the connection is working
     graph.query("RETURN 1 as n")
 
@@ -474,13 +405,9 @@ def test_neo4j_explicit_close(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_error_after_close(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_error_after_close(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that Neo4jGraph operations raise proper errors after closing."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     graph.query("RETURN 1")  # Should work
     graph.close()
 
@@ -507,18 +434,10 @@ def test_neo4j_error_after_close(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_concurrent_connections(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_concurrent_connections(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that multiple Neo4jGraph instances can be used independently."""
-    graph1 = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
-    graph2 = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph1 = Neo4jGraph(**neo4j_credentials)
+    graph2 = Neo4jGraph(**neo4j_credentials)
 
     # Both connections should work independently
     assert graph1.query("RETURN 1 as n") == [{"n": 1}]
@@ -537,18 +456,10 @@ def test_neo4j_concurrent_connections(neo4j_credentials: Dict[str, str]) -> None
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_nested_context_managers(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_nested_context_managers(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that nested context managers work correctly."""
-    with Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    ) as graph1:
-        with Neo4jGraph(
-            url=neo4j_credentials["url"],
-            username=neo4j_credentials["username"],
-            password=neo4j_credentials["password"],
-        ) as graph2:
+    with Neo4jGraph(**neo4j_credentials) as graph1:
+        with Neo4jGraph(**neo4j_credentials) as graph2:
             # Both connections should work
             assert graph1.query("RETURN 1 as n") == [{"n": 1}]
             assert graph2.query("RETURN 2 as n") == [{"n": 2}]
@@ -575,20 +486,16 @@ def test_neo4j_nested_context_managers(neo4j_credentials: Dict[str, str]) -> Non
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_multiple_close(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_multiple_close(neo4j_credentials: Neo4jCredentials) -> None:
     """Test that Neo4jGraph can be closed multiple times without error."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Test that multiple closes don't raise errors
     graph.close()
     graph.close()  # This should not raise an error
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_invalid_url(neo4j_credentials: Dict[str, str]) -> None:
+def test_invalid_url(neo4j_credentials: Neo4jCredentials) -> None:
     """Test initializing with invalid credentials raises ValueError."""
     # Parse the original URL
     parsed_url = urllib.parse.urlparse(neo4j_credentials["url"])
@@ -610,7 +517,7 @@ def test_invalid_url(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_invalid_credentials(neo4j_credentials: Dict[str, str]) -> None:
+def test_invalid_credentials(neo4j_credentials: Neo4jCredentials) -> None:
     """Test initializing with invalid credentials raises ValueError."""
 
     with pytest.raises(ValueError) as exc_info:

--- a/libs/neo4j/tests/integration_tests/utils.py
+++ b/libs/neo4j/tests/integration_tests/utils.py
@@ -1,0 +1,7 @@
+from typing import TypedDict
+
+
+class Neo4jCredentials(TypedDict):
+    url: str
+    username: str
+    password: str

--- a/libs/neo4j/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/neo4j/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -96,6 +96,7 @@ def test_neo4jvector_euclidean(neo4j_credentials: Neo4jCredentials) -> None:
         embedding=FakeEmbeddingsWithOsDimension(),
         pre_delete_collection=True,
         distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo")]

--- a/libs/neo4j/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/neo4j/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -14,6 +14,7 @@ from langchain_neo4j.vectorstores.neo4j_vector import (
     _get_search_index_query,
 )
 from langchain_neo4j.vectorstores.utils import DistanceStrategy
+from tests.integration_tests.utils import Neo4jCredentials
 from tests.integration_tests.vectorstores.fake_embeddings import (
     AngularTwoDimensionalEmbeddings,
     FakeEmbeddings,
@@ -88,14 +89,11 @@ def test_neo4jvector() -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_euclidean(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_euclidean(neo4j_credentials: Neo4jCredentials) -> None:
     """Test euclidean distance"""
     docsearch = Neo4jVector.from_texts(
         texts=texts,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         distance_strategy=DistanceStrategy.EUCLIDEAN_DISTANCE,
     )
@@ -106,17 +104,15 @@ def test_neo4jvector_euclidean(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_embeddings(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_embeddings(neo4j_credentials: Neo4jCredentials) -> None:
     """Test end to end construction with embeddings and search."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     docsearch = Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo")]
@@ -125,24 +121,22 @@ def test_neo4jvector_embeddings(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_catch_wrong_index_name(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_catch_wrong_index_name(
+    neo4j_credentials: Neo4jCredentials,
+) -> None:
     """Test if index name is misspelled, but node label and property are correct."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     existing = Neo4jVector.from_existing_index(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="test",
+        **neo4j_credentials,
     )
     output = existing.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo")]
@@ -151,25 +145,23 @@ def test_neo4jvector_catch_wrong_index_name(neo4j_credentials: Dict[str, str]) -
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_catch_wrong_node_label(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_catch_wrong_node_label(
+    neo4j_credentials: Neo4jCredentials,
+) -> None:
     """Test if node label is misspelled, but index name is correct."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     existing = Neo4jVector.from_existing_index(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="vector",
         node_label="test",
+        **neo4j_credentials,
     )
     output = existing.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo")]
@@ -178,17 +170,15 @@ def test_neo4jvector_catch_wrong_node_label(neo4j_credentials: Dict[str, str]) -
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_with_metadatas(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_with_metadatas(neo4j_credentials: Neo4jCredentials) -> None:
     """Test end to end construction and search."""
     metadatas = [{"page": str(i)} for i in range(len(texts))]
     docsearch = Neo4jVector.from_texts(
         texts=texts,
         embedding=FakeEmbeddingsWithOsDimension(),
         metadatas=metadatas,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo", metadata={"page": "0"})]
@@ -198,7 +188,7 @@ def test_neo4jvector_with_metadatas(neo4j_credentials: Dict[str, str]) -> None:
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4jvector_with_metadatas_with_scores(
-    neo4j_credentials: Dict[str, str],
+    neo4j_credentials: Neo4jCredentials,
 ) -> None:
     """Test end to end construction and search."""
     metadatas = [{"page": str(i)} for i in range(len(texts))]
@@ -206,10 +196,8 @@ def test_neo4jvector_with_metadatas_with_scores(
         texts=texts,
         embedding=FakeEmbeddingsWithOsDimension(),
         metadatas=metadatas,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     output = [
         (doc, round(score, 1))
@@ -221,17 +209,15 @@ def test_neo4jvector_with_metadatas_with_scores(
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_relevance_score(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_relevance_score(neo4j_credentials: Neo4jCredentials) -> None:
     """Test to make sure the relevance score is scaled to 0-1."""
     metadatas = [{"page": str(i)} for i in range(len(texts))]
     docsearch = Neo4jVector.from_texts(
         texts=texts,
         embedding=FakeEmbeddingsWithOsDimension(),
         metadatas=metadatas,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
 
     output = docsearch.similarity_search_with_relevance_scores("foo", k=3)
@@ -250,7 +236,7 @@ def test_neo4jvector_relevance_score(neo4j_credentials: Dict[str, str]) -> None:
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4jvector_retriever_search_threshold(
-    neo4j_credentials: Dict[str, str],
+    neo4j_credentials: Neo4jCredentials,
 ) -> None:
     """Test using retriever for searching with threshold."""
     metadatas = [{"page": str(i)} for i in range(len(texts))]
@@ -258,10 +244,8 @@ def test_neo4jvector_retriever_search_threshold(
         texts=texts,
         embedding=FakeEmbeddingsWithOsDimension(),
         metadatas=metadatas,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
 
     retriever = docsearch.as_retriever(
@@ -278,16 +262,14 @@ def test_neo4jvector_retriever_search_threshold(
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_custom_return_neo4jvector(neo4j_credentials: Dict[str, str]) -> None:
+def test_custom_return_neo4jvector(neo4j_credentials: Neo4jCredentials) -> None:
     """Test end to end construction and search."""
     docsearch = Neo4jVector.from_texts(
         texts=["test"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         retrieval_query="RETURN 'foo' AS text, score, {test: 'test'} AS metadata",
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo", metadata={"test": "test"})]
@@ -296,37 +278,31 @@ def test_custom_return_neo4jvector(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_prefer_indexname(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_prefer_indexname(neo4j_credentials: Neo4jCredentials) -> None:
     """Test using when two indexes are found, prefer by index_name."""
     Neo4jVector.from_texts(
         texts=["foo"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
 
     Neo4jVector.from_texts(
         texts=["bar"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="foo",
         node_label="Test",
         embedding_node_property="vector",
         text_node_property="info",
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
 
     existing_index = Neo4jVector.from_existing_index(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="foo",
         text_node_property="info",
+        **neo4j_credentials,
     )
 
     output = existing_index.similarity_search("bar", k=1)
@@ -335,37 +311,33 @@ def test_neo4jvector_prefer_indexname(neo4j_credentials: Dict[str, str]) -> None
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_prefer_indexname_insert(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_prefer_indexname_insert(
+    neo4j_credentials: Neo4jCredentials,
+) -> None:
     """Test using when two indexes are found, prefer by index_name."""
     Neo4jVector.from_texts(
         texts=["baz"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
 
     Neo4jVector.from_texts(
         texts=["foo"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="foo",
         node_label="Test",
         embedding_node_property="vector",
         text_node_property="info",
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
 
     existing_index = Neo4jVector.from_existing_index(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="foo",
         text_node_property="info",
+        **neo4j_credentials,
     )
 
     existing_index.add_documents([Document(page_content="bar", metadata={})])
@@ -379,18 +351,16 @@ def test_neo4jvector_prefer_indexname_insert(neo4j_credentials: Dict[str, str]) 
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_hybrid(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_hybrid(neo4j_credentials: Neo4jCredentials) -> None:
     """Test end to end construction with hybrid search."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     docsearch = Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         search_type=SearchType.HYBRID,
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo")]
@@ -399,18 +369,16 @@ def test_neo4jvector_hybrid(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_hybrid_deduplicate(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_hybrid_deduplicate(neo4j_credentials: Neo4jCredentials) -> None:
     """Test result deduplication with hybrid search."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     docsearch = Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         search_type=SearchType.HYBRID,
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=3)
 
@@ -424,19 +392,19 @@ def test_neo4jvector_hybrid_deduplicate(neo4j_credentials: Dict[str, str]) -> No
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_hybrid_retrieval_query(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_hybrid_retrieval_query(
+    neo4j_credentials: Neo4jCredentials,
+) -> None:
     """Test custom retrieval_query with hybrid search."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     docsearch = Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         search_type=SearchType.HYBRID,
         retrieval_query="RETURN 'moo' AS text, score, {test: 'test'} AS metadata",
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="moo", metadata={"test": "test"})]
@@ -445,19 +413,19 @@ def test_neo4jvector_hybrid_retrieval_query(neo4j_credentials: Dict[str, str]) -
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_hybrid_retrieval_query2(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_hybrid_retrieval_query2(
+    neo4j_credentials: Neo4jCredentials,
+) -> None:
     """Test custom retrieval_query with hybrid search."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     docsearch = Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         search_type=SearchType.HYBRID,
         retrieval_query="RETURN node.text AS text, score, {test: 'test'} AS metadata",
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo", metadata={"test": "test"})]
@@ -466,26 +434,22 @@ def test_neo4jvector_hybrid_retrieval_query2(neo4j_credentials: Dict[str, str]) 
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_missing_keyword(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_missing_keyword(neo4j_credentials: Neo4jCredentials) -> None:
     """Test hybrid search with missing keyword_index_search."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     docsearch = Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     try:
         Neo4jVector.from_existing_index(
             embedding=FakeEmbeddingsWithOsDimension(),
-            url=neo4j_credentials["url"],
-            username=neo4j_credentials["username"],
-            password=neo4j_credentials["password"],
             index_name="vector",
             search_type=SearchType.HYBRID,
+            **neo4j_credentials,
         )
     except ValueError as e:
         assert str(e) == (
@@ -495,27 +459,23 @@ def test_neo4jvector_missing_keyword(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_hybrid_from_existing(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_hybrid_from_existing(neo4j_credentials: Neo4jCredentials) -> None:
     """Test hybrid search with missing keyword_index_search."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         search_type=SearchType.HYBRID,
+        **neo4j_credentials,
     )
     existing = Neo4jVector.from_existing_index(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="vector",
         keyword_index_name="keyword",
         search_type=SearchType.HYBRID,
+        **neo4j_credentials,
     )
 
     output = existing.similarity_search("foo", k=1)
@@ -525,19 +485,17 @@ def test_neo4jvector_hybrid_from_existing(neo4j_credentials: Dict[str, str]) -> 
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_from_existing_graph(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_from_existing_graph(neo4j_credentials: Neo4jCredentials) -> None:
     """Test from_existing_graph with a single property."""
     graph = Neo4jVector.from_texts(
         texts=["test"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="foo",
         node_label="Foo",
         embedding_node_property="vector",
         text_node_property="info",
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
 
     graph.query("MATCH (n) DETACH DELETE n")
@@ -546,13 +504,11 @@ def test_neo4jvector_from_existing_graph(neo4j_credentials: Dict[str, str]) -> N
 
     existing = Neo4jVector.from_existing_graph(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="vector",
         node_label="Test",
         text_node_properties=["name"],
         embedding_node_property="embedding",
+        **neo4j_credentials,
     )
 
     output = existing.similarity_search("foo", k=1)
@@ -563,20 +519,18 @@ def test_neo4jvector_from_existing_graph(neo4j_credentials: Dict[str, str]) -> N
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4jvector_from_existing_graph_hybrid(
-    neo4j_credentials: Dict[str, str],
+    neo4j_credentials: Neo4jCredentials,
 ) -> None:
     """Test from_existing_graph hybrid with a single property."""
     graph = Neo4jVector.from_texts(
         texts=["test"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="foo",
         node_label="Foo",
         embedding_node_property="vector",
         text_node_property="info",
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
 
     graph.query("MATCH (n) DETACH DELETE n")
@@ -585,14 +539,12 @@ def test_neo4jvector_from_existing_graph_hybrid(
 
     existing = Neo4jVector.from_existing_graph(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="vector",
         node_label="Test",
         text_node_properties=["name"],
         embedding_node_property="embedding",
         search_type=SearchType.HYBRID,
+        **neo4j_credentials,
     )
 
     output = existing.similarity_search("foo", k=1)
@@ -603,20 +555,18 @@ def test_neo4jvector_from_existing_graph_hybrid(
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4jvector_from_existing_graph_multiple_properties(
-    neo4j_credentials: Dict[str, str],
+    neo4j_credentials: Neo4jCredentials,
 ) -> None:
     """Test from_existing_graph with a two property."""
     graph = Neo4jVector.from_texts(
         texts=["test"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="foo",
         node_label="Foo",
         embedding_node_property="vector",
         text_node_property="info",
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     graph.query("MATCH (n) DETACH DELETE n")
 
@@ -624,13 +574,11 @@ def test_neo4jvector_from_existing_graph_multiple_properties(
 
     existing = Neo4jVector.from_existing_graph(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="vector",
         node_label="Test",
         text_node_properties=["name", "name2"],
         embedding_node_property="embedding",
+        **neo4j_credentials,
     )
 
     output = existing.similarity_search("foo", k=1)
@@ -641,20 +589,18 @@ def test_neo4jvector_from_existing_graph_multiple_properties(
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4jvector_from_existing_graph_multiple_properties_hybrid(
-    neo4j_credentials: Dict[str, str],
+    neo4j_credentials: Neo4jCredentials,
 ) -> None:
     """Test from_existing_graph with a two property."""
     graph = Neo4jVector.from_texts(
         texts=["test"],
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="foo",
         node_label="Foo",
         embedding_node_property="vector",
         text_node_property="info",
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     graph.query("MATCH (n) DETACH DELETE n")
 
@@ -662,14 +608,12 @@ def test_neo4jvector_from_existing_graph_multiple_properties_hybrid(
 
     existing = Neo4jVector.from_existing_graph(
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         index_name="vector",
         node_label="Test",
         text_node_properties=["name", "name2"],
         embedding_node_property="embedding",
         search_type=SearchType.HYBRID,
+        **neo4j_credentials,
     )
 
     output = existing.similarity_search("foo", k=1)
@@ -679,18 +623,16 @@ def test_neo4jvector_from_existing_graph_multiple_properties_hybrid(
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_special_character(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_special_character(neo4j_credentials: Neo4jCredentials) -> None:
     """Test removing lucene."""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(texts, text_embeddings))
     docsearch = Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         search_type=SearchType.HYBRID,
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search(
         "It is the end of the world. Take shelter!",
@@ -705,18 +647,16 @@ def test_neo4jvector_special_character(neo4j_credentials: Dict[str, str]) -> Non
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_hybrid_score_normalization(neo4j_credentials: Dict[str, str]) -> None:
+def test_hybrid_score_normalization(neo4j_credentials: Neo4jCredentials) -> None:
     """Test if we can get two 1.0 documents with RRF"""
     text_embeddings = FakeEmbeddingsWithOsDimension().embed_documents(texts)
     text_embedding_pairs = list(zip(["foo"], text_embeddings))
     docsearch = Neo4jVector.from_embeddings(
         text_embeddings=text_embedding_pairs,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
         search_type=SearchType.HYBRID,
+        **neo4j_credentials,
     )
     # Remove deduplication part of the query
     rrf_query = (
@@ -743,7 +683,7 @@ def test_hybrid_score_normalization(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_index_fetching(neo4j_credentials: Dict[str, str]) -> None:
+def test_index_fetching(neo4j_credentials: Neo4jCredentials) -> None:
     """testing correct index creation and fetching"""
     embeddings = FakeEmbeddings()
 
@@ -752,22 +692,18 @@ def test_index_fetching(neo4j_credentials: Dict[str, str]) -> None:
     ) -> Neo4jVector:
         return Neo4jVector.from_existing_graph(
             embedding=embeddings,
-            url=neo4j_credentials["url"],
-            username=neo4j_credentials["username"],
-            password=neo4j_credentials["password"],
             index_name=index,
             node_label=node_label,
             text_node_properties=text_properties,
             embedding_node_property="embedding",
+            **neo4j_credentials,
         )
 
     def fetch_store(index_name: str) -> Neo4jVector:
         store = Neo4jVector.from_existing_index(
             embedding=embeddings,
-            url=neo4j_credentials["url"],
-            username=neo4j_credentials["username"],
-            password=neo4j_credentials["password"],
             index_name=index_name,
+            **neo4j_credentials,
         )
         return store
 
@@ -789,7 +725,7 @@ def test_index_fetching(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_retrieval_params(neo4j_credentials: Dict[str, str]) -> None:
+def test_retrieval_params(neo4j_credentials: Neo4jCredentials) -> None:
     """Test if we use parameters in retrieval query"""
     docsearch = Neo4jVector.from_texts(
         texts=texts,
@@ -798,9 +734,7 @@ def test_retrieval_params(neo4j_credentials: Dict[str, str]) -> None:
         retrieval_query="""
         RETURN $test as text, score, {test: $test1} AS metadata
         """,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
+        **neo4j_credentials,
     )
 
     output = docsearch.similarity_search(
@@ -814,12 +748,9 @@ def test_retrieval_params(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_retrieval_dictionary(neo4j_credentials: Dict[str, str]) -> None:
+def test_retrieval_dictionary(neo4j_credentials: Neo4jCredentials) -> None:
     """Test if we use parameters in retrieval query"""
     docsearch = Neo4jVector.from_texts(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         texts=texts,
         embedding=FakeEmbeddings(),
         pre_delete_collection=True,
@@ -830,6 +761,7 @@ def test_retrieval_dictionary(neo4j_credentials: Dict[str, str]) -> None:
             skills: ["Python", "Data Analysis", "Machine Learning"]} as text, 
             score, {} AS metadata
         """,
+        **neo4j_credentials,
     )
     expected_output = [
         Document(
@@ -853,15 +785,13 @@ def test_retrieval_dictionary(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_metadata_filters_type1(neo4j_credentials: Dict[str, str]) -> None:
+def test_metadata_filters_type1(neo4j_credentials: Neo4jCredentials) -> None:
     """Test metadata filters"""
     docsearch = Neo4jVector.from_documents(
         DOCUMENTS,
         embedding=FakeEmbeddings(),
         pre_delete_collection=True,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
+        **neo4j_credentials,
     )
     # We don't test type 5, because LIKE has very SQL specific examples
     for example in (
@@ -891,16 +821,14 @@ def test_metadata_filters_type1(neo4j_credentials: Dict[str, str]) -> None:
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_relationship_index(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_relationship_index(neo4j_credentials: Neo4jCredentials) -> None:
     """Test end to end construction and search."""
     embeddings = FakeEmbeddingsWithOsDimension()
     docsearch = Neo4jVector.from_texts(
         texts=texts,
         embedding=embeddings,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     # Ingest data
     docsearch.query(
@@ -926,9 +854,7 @@ OPTIONS {indexConfig: {
     relationship_index = Neo4jVector.from_existing_relationship_index(
         embeddings,
         index_name="relationship",
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
+        **neo4j_credentials,
     )
 
     output = relationship_index.similarity_search("foo", k=1)
@@ -939,17 +865,15 @@ OPTIONS {indexConfig: {
 
 @pytest.mark.usefixtures("clear_neo4j_database")
 def test_neo4jvector_relationship_index_retrieval(
-    neo4j_credentials: Dict[str, str],
+    neo4j_credentials: Neo4jCredentials,
 ) -> None:
     """Test end to end construction and search."""
     embeddings = FakeEmbeddingsWithOsDimension()
     docsearch = Neo4jVector.from_texts(
         texts=texts,
         embedding=embeddings,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     # Ingest data
     docsearch.query(
@@ -980,9 +904,7 @@ OPTIONS {indexConfig: {
         embeddings,
         index_name="relationship",
         retrieval_query=retrieval_query,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
+        **neo4j_credentials,
     )
 
     output = relationship_index.similarity_search("foo", k=1)
@@ -992,7 +914,9 @@ OPTIONS {indexConfig: {
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4j_max_marginal_relevance_search(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4j_max_marginal_relevance_search(
+    neo4j_credentials: Neo4jCredentials,
+) -> None:
     """
     Test end to end construction and MMR search.
     The embedding function used here ensures `texts` become
@@ -1015,9 +939,7 @@ def test_neo4j_max_marginal_relevance_search(neo4j_credentials: Dict[str, str]) 
         metadatas=metadatas,
         embedding=AngularTwoDimensionalEmbeddings(),
         pre_delete_collection=True,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
+        **neo4j_credentials,
     )
 
     expected_set = {
@@ -1035,15 +957,15 @@ def test_neo4j_max_marginal_relevance_search(neo4j_credentials: Dict[str, str]) 
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_effective_search_ratio(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_effective_search_ratio(
+    neo4j_credentials: Neo4jCredentials,
+) -> None:
     """Test effective search parameter."""
     docsearch = Neo4jVector.from_texts(
         texts=texts,
         embedding=FakeEmbeddingsWithOsDimension(),
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
         pre_delete_collection=True,
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=2, effective_search_ratio=2)
     assert len(output) == 2
@@ -1058,13 +980,9 @@ def test_neo4jvector_effective_search_ratio(neo4j_credentials: Dict[str, str]) -
 
 
 @pytest.mark.usefixtures("clear_neo4j_database")
-def test_neo4jvector_passing_graph_object(neo4j_credentials: Dict[str, str]) -> None:
+def test_neo4jvector_passing_graph_object(neo4j_credentials: Neo4jCredentials) -> None:
     """Test end to end construction and search with passing graph object."""
-    graph = Neo4jGraph(
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
-    )
+    graph = Neo4jGraph(**neo4j_credentials)
     # Rewrite env vars to make sure it fails if env is used
     old_url = os.environ["NEO4J_URI"]
     os.environ["NEO4J_URI"] = "foo"
@@ -1073,9 +991,7 @@ def test_neo4jvector_passing_graph_object(neo4j_credentials: Dict[str, str]) -> 
         embedding=FakeEmbeddingsWithOsDimension(),
         graph=graph,
         pre_delete_collection=True,
-        url=neo4j_credentials["url"],
-        username=neo4j_credentials["username"],
-        password=neo4j_credentials["password"],
+        **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
     assert output == [Document(page_content="foo")]

--- a/libs/neo4j/tests/unit_tests/chat_message_histories/test_neo4j_chat_message_history.py
+++ b/libs/neo4j/tests/unit_tests/chat_message_histories/test_neo4j_chat_message_history.py
@@ -1,6 +1,4 @@
 import gc
-from types import ModuleType
-from typing import Mapping, Sequence, Union
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,27 +28,6 @@ def test_messages_setter() -> None:
         with pytest.raises(NotImplementedError) as exc_info:
             message_store.messages = []
         assert "Direct assignment to 'messages' is not allowed." in str(exc_info.value)
-
-
-def test_import_error() -> None:
-    """Test that ImportError is raised when neo4j package is not installed."""
-    original_import = __import__
-
-    def mock_import(
-        name: str,
-        globals: Union[Mapping[str, object], None] = None,
-        locals: Union[Mapping[str, object], None] = None,
-        fromlist: Sequence[str] = (),
-        level: int = 0,
-    ) -> ModuleType:
-        if name == "neo4j":
-            raise ImportError()
-        return original_import(name, globals, locals, fromlist, level)
-
-    with patch("builtins.__import__", side_effect=mock_import):
-        with pytest.raises(ImportError) as exc_info:
-            Neo4jChatMessageHistory("test_session")
-        assert "Could not import neo4j python package." in str(exc_info.value)
 
 
 def test_driver_closed_on_delete() -> None:

--- a/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
+++ b/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
@@ -1,5 +1,4 @@
-from types import ModuleType
-from typing import Any, Dict, Generator, Mapping, Sequence, Union
+from typing import Any, Dict, Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -170,27 +169,6 @@ def test_multiple_close_calls_safe(mock_neo4j_driver: MagicMock) -> None:
 
     # Second close should not raise an error
     graph.close()  # Should not raise any exception
-
-
-def test_import_error() -> None:
-    """Test that ImportError is raised when neo4j package is not installed."""
-    original_import = __import__
-
-    def mock_import(
-        name: str,
-        globals: Union[Mapping[str, object], None] = None,
-        locals: Union[Mapping[str, object], None] = None,
-        fromlist: Sequence[str] = (),
-        level: int = 0,
-    ) -> ModuleType:
-        if name == "neo4j":
-            raise ImportError()
-        return original_import(name, globals, locals, fromlist, level)
-
-    with patch("builtins.__import__", side_effect=mock_import):
-        with pytest.raises(ImportError) as exc_info:
-            Neo4jGraph()
-        assert "Could not import neo4j python package." in str(exc_info.value)
 
 
 def test_neo4j_graph_init_with_empty_credentials() -> None:


### PR DESCRIPTION
# Description

- Removes unneeded `try: import neo4j` statements.
- Removes tests which test for errors raised when these statements fail.
- Adds `clear_neo4j_database` and `neo4j_credentials` fixtures to the integration tests streamlining handling of database credentials in these tests and making them less flaky.
- Updates integration tests to use these fixtures.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

## Checklist

- [X] Unit tests updated
- [X] Integration tests updated
- [X] CHANGELOG.md updated
