### PR TITLE
Fixes extract_paths infinite loop

### DIFF
--- a/libs/neo4j/langchain_neo4j/chains/graph_qa/cypher_utils.py
+++ b/libs/neo4j/langchain_neo4j/chains/graph_qa/cypher_utils.py
@@ -72,7 +72,7 @@ class CypherQueryCorrector:
                 m for i, m in enumerate(matched) if i not in [1, len(matched) - 1]
             ]
             path = "".join(matched)
-            idx = query.find(path) + len(path) - len(matched[-1])
+            idx = idx + query[idx:].find(path) + len(path) - len(matched[-1])
             paths.append(path)
         return paths
 

--- a/libs/neo4j/tests/unit_tests/chains/test_cypher_utils.py
+++ b/libs/neo4j/tests/unit_tests/chains/test_cypher_utils.py
@@ -1,0 +1,35 @@
+import pytest
+
+from langchain_neo4j.chains.graph_qa.cypher_utils import CypherQueryCorrector, Schema
+
+schema = Schema(left_node="Actor", relation="ACTED_IN", right_node="Movie")
+corrector = CypherQueryCorrector([schema])
+
+
+@pytest.mark.parametrize(
+    "description, query, expected",
+    [
+        (
+            "Correct query",
+            "MATCH (a:Actor)-[r]->(b:Movie)",
+            "MATCH (a:Actor)-[r]->(b:Movie)",
+        ),
+        (
+            "Reversed relation",
+            "MATCH (a:Actor)<-[r]-(b:Movie)",
+            "MATCH (a:Actor)-[r]->(b:Movie)",
+        ),
+        (
+            "Repeated query",
+            "MATCH (a)-[r]->(b) MATCH (a)-[r]->(b)",
+            "MATCH (a)-[r]->(b) MATCH (a)-[r]->(b)",
+        ),
+        (
+            "Query doesn't match schema returns empty",
+            "MATCH (a:Director)-[r:ACTED_IN]->(b:Movie)",
+            "",
+        ),
+    ],
+)
+def test_cypher_query_corrector(description, query, expected):
+    assert corrector.correct_query(query) == expected, f"{description} failed"

--- a/libs/neo4j/tests/unit_tests/chains/test_cypher_utils.py
+++ b/libs/neo4j/tests/unit_tests/chains/test_cypher_utils.py
@@ -31,5 +31,5 @@ corrector = CypherQueryCorrector([schema])
         ),
     ],
 )
-def test_cypher_query_corrector(description, query, expected):
+def test_cypher_query_corrector(description: str, query: str, expected: str) -> None:
     assert corrector.correct_query(query) == expected, f"{description} failed"


### PR DESCRIPTION
# Description

This PR fixes the `extract_paths` method of the `CypherQueryCorrector`. Previously this function would enter into an infinite loop whenever there was a repeated path in a Cypher query. Unit tests have also been added to test the `CypherQueryCorrector`.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [X] Unit tests
- [ ] Integration tests
- [X] Manual tests

## Checklist

- [X] Unit tests updated
- [ ] Integration tests updated
- [ ] CHANGELOG.md updated
