### PR TITLE
Revert "FIX: Added 'chat_history' as an argument to the self.qa_chain.invoke() in GraphCypherQAChain"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@
 - Introduced a `delete_session_node` parameter to the `clear` method in `Neo4jChatMessageHistory` for optional deletion of the `Session` node.
 - Added `neo4j-graphrag` to the dependencies.
 
-### Fixed
-
-
 ## 0.3.0
 
 ### Added

--- a/libs/neo4j/langchain_neo4j/chains/graph_qa/cypher.py
+++ b/libs/neo4j/langchain_neo4j/chains/graph_qa/cypher.py
@@ -168,7 +168,7 @@ class GraphCypherQAChain(Chain):
 
         :meta private:
         """
-        return [self.input_key, "chat_history"]
+        return [self.input_key]
 
     @property
     def output_keys(self) -> List[str]:
@@ -374,11 +374,7 @@ class GraphCypherQAChain(Chain):
                 )
             else:
                 final_result = self.qa_chain.invoke(
-                    {
-                        "question": question,
-                        "context": context,
-                        "chat_history": inputs.get("chat_history", ""),
-                    },
+                    {"question": question, "context": context},
                     callbacks=callbacks,
                 )
 

--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -957,7 +957,8 @@ class Neo4jVector(VectorStore):
 
         if search_type == SearchType.HYBRID and not keyword_index_name:
             raise ValueError(
-                "keyword_index name has to be specified when using hybrid search option"
+                "keyword_index name has to be specified "
+                "when using hybrid search option"
             )
 
         store = cls(

--- a/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
+++ b/libs/neo4j/tests/integration_tests/graphs/test_neo4j.py
@@ -410,9 +410,9 @@ def test_neo4j_error_after_close(neo4j_credentials: Neo4jCredentials) -> None:
     # Test various operations after close
     try:
         graph.refresh_schema()
-        assert False, (
-            "Expected RuntimeError when refreshing schema on closed connection"
-        )
+        assert (
+            False
+        ), "Expected RuntimeError when refreshing schema on closed connection"
     except RuntimeError as e:
         assert "connection has been closed" in str(e)
 

--- a/libs/neo4j/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/neo4j/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -452,7 +452,7 @@ def test_neo4jvector_missing_keyword(neo4j_credentials: Neo4jCredentials) -> Non
         )
     except ValueError as e:
         assert str(e) == (
-            "keyword_index name has to be specified when using hybrid search option"
+            "keyword_index name has to be specified when " "using hybrid search option"
         )
     drop_vector_indexes(docsearch)
 
@@ -499,7 +499,7 @@ def test_neo4jvector_from_existing_graph(neo4j_credentials: Neo4jCredentials) ->
 
     graph.query("MATCH (n) DETACH DELETE n")
 
-    graph.query("CREATE (:Test {name:'Foo'}),(:Test {name:'Bar'})")
+    graph.query("CREATE (:Test {name:'Foo'})," "(:Test {name:'Bar'})")
 
     existing = Neo4jVector.from_existing_graph(
         embedding=FakeEmbeddingsWithOsDimension(),
@@ -534,7 +534,7 @@ def test_neo4jvector_from_existing_graph_hybrid(
 
     graph.query("MATCH (n) DETACH DELETE n")
 
-    graph.query("CREATE (:Test {name:'foo'}),(:Test {name:'Bar'})")
+    graph.query("CREATE (:Test {name:'foo'})," "(:Test {name:'Bar'})")
 
     existing = Neo4jVector.from_existing_graph(
         embedding=FakeEmbeddingsWithOsDimension(),
@@ -569,7 +569,7 @@ def test_neo4jvector_from_existing_graph_multiple_properties(
     )
     graph.query("MATCH (n) DETACH DELETE n")
 
-    graph.query("CREATE (:Test {name:'Foo', name2: 'Fooz'}),(:Test {name:'Bar'})")
+    graph.query("CREATE (:Test {name:'Foo', name2: 'Fooz'})," "(:Test {name:'Bar'})")
 
     existing = Neo4jVector.from_existing_graph(
         embedding=FakeEmbeddingsWithOsDimension(),
@@ -603,7 +603,7 @@ def test_neo4jvector_from_existing_graph_multiple_properties_hybrid(
     )
     graph.query("MATCH (n) DETACH DELETE n")
 
-    graph.query("CREATE (:Test {name:'Foo', name2: 'Fooz'}),(:Test {name:'Bar'})")
+    graph.query("CREATE (:Test {name:'Foo', name2: 'Fooz'})," "(:Test {name:'Bar'})")
 
     existing = Neo4jVector.from_existing_graph(
         embedding=FakeEmbeddingsWithOsDimension(),

--- a/libs/neo4j/tests/unit_tests/chains/test_graph_qa.py
+++ b/libs/neo4j/tests/unit_tests/chains/test_graph_qa.py
@@ -1,7 +1,7 @@
 import pathlib
 from csv import DictReader
 from typing import Any, Dict, List
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain.memory import ConversationBufferMemory, ReadOnlySharedMemory
@@ -312,36 +312,6 @@ def test_graph_cypher_qa_chain() -> None:
     # If we get here without a key error, that means memory
     # was used properly to create prompts.
     assert True
-
-
-def test_chat_history_support() -> None:
-    """Test that chat_history is properly handled in the chain."""
-    qa_chain_mock = MagicMock()
-    chain = GraphCypherQAChain.from_llm(
-        llm=FakeLLM(),
-        graph=FakeGraphStore(),
-        verbose=True,
-        return_intermediate_steps=False,
-        allow_dangerous_requests=True,
-    )
-    chain.qa_chain = qa_chain_mock
-    assert "chat_history" in chain.input_keys
-
-    # Works when history is included
-    chat_history = "Mock conversation history"
-    chain._call({"query": "test question", "chat_history": chat_history})
-    chain.qa_chain.invoke.assert_called_with(
-        {"question": "test question", "context": [], "chat_history": chat_history},
-        callbacks=ANY,
-    )
-
-    # Works when history is NOT included
-    chain.qa_chain.reset_mock()
-    chain._call({"query": "test question"})
-
-    chain.qa_chain.invoke.assert_called_with(
-        {"question": "test question", "context": [], "chat_history": ""}, callbacks=ANY
-    )
 
 
 def test_cypher_generation_failure() -> None:

--- a/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
+++ b/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
@@ -447,17 +447,12 @@ def test_neo4jvector_fts_vector_node_label_mismatch(neo4j_vector_factory: Any) -
     mock_embedding = MagicMock()
     mock_embedding.embed_query.return_value = [0.1] * embedding_dimension
 
-    with (
-        patch.object(
-            Neo4jVector,
-            "retrieve_existing_index",
-            return_value=(embedding_dimension, "NODE"),
-        ),
-        patch.object(
-            Neo4jVector,
-            "retrieve_existing_fts_index",
-            return_value="DifferentNodeLabel",
-        ),
+    with patch.object(
+        Neo4jVector,
+        "retrieve_existing_index",
+        return_value=(embedding_dimension, "NODE"),
+    ), patch.object(
+        Neo4jVector, "retrieve_existing_fts_index", return_value="DifferentNodeLabel"
     ):
         with pytest.raises(ValueError) as exc_info:
             neo4j_vector_factory(
@@ -552,17 +547,12 @@ def test_from_existing_index_fts_vector_node_label_mismatch(
     mock_embedding = MagicMock()
     mock_embedding.embed_query.return_value = [0.1] * embedding_dimension
 
-    with (
-        patch.object(
-            Neo4jVector,
-            "retrieve_existing_index",
-            return_value=(embedding_dimension, "NODE"),
-        ),
-        patch.object(
-            Neo4jVector,
-            "retrieve_existing_fts_index",
-            return_value="DifferentNodeLabel",
-        ),
+    with patch.object(
+        Neo4jVector,
+        "retrieve_existing_index",
+        return_value=(embedding_dimension, "NODE"),
+    ), patch.object(
+        Neo4jVector, "retrieve_existing_fts_index", return_value="DifferentNodeLabel"
     ):
         with pytest.raises(ValueError) as exc_info:
             neo4j_vector_factory(
@@ -710,13 +700,10 @@ def test_from_existing_graph_fts_vector_node_label_mismatch(
 ) -> None:
     mock_embedding = MagicMock()
     mock_embedding.embed_query.return_value = [0.1] * 64
-    with (
-        patch.object(Neo4jVector, "retrieve_existing_index", return_value=(64, "NODE")),
-        patch.object(
-            Neo4jVector,
-            "retrieve_existing_fts_index",
-            return_value="DifferentNodeLabel",
-        ),
+    with patch.object(
+        Neo4jVector, "retrieve_existing_index", return_value=(64, "NODE")
+    ), patch.object(
+        Neo4jVector, "retrieve_existing_fts_index", return_value="DifferentNodeLabel"
     ):
         with pytest.raises(ValueError) as exc_info:
             neo4j_vector_factory(


### PR DESCRIPTION
Reverts langchain-ai/langchain-neo4j#51 due to issues identified during further testing. The changes did not work as expected and required users to provide a chat_history, which should not be mandatory.

Moreover, the currently recommended approach for managing message history is through [LangGraph persistence](https://python.langchain.com/docs/how_to/message_history/), making this change unnecessary.