### PR TITLE
Neo4jChatMessageHistory custom DBs

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -84,9 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     services:
       neo4j:
-        image: neo4j:5.24.2
+        image: neo4j:5.24.2-enterprise
         env:
-          NEO4J_AUTH: neo4j/pleaseletmein
+          NEO4J_AUTH: neo4j/password
           NEO4J_ACCEPT_LICENSE_AGREEMENT: 'eval'
           NEO4J_PLUGINS: '["apoc"]'
         ports:

--- a/libs/neo4j/langchain_neo4j/chat_message_histories/neo4j.py
+++ b/libs/neo4j/langchain_neo4j/chat_message_histories/neo4j.py
@@ -73,6 +73,7 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
         self._driver.execute_query(
             CREATE_SESSION_NODE_QUERY.format(node_label=self._node_label),
             {"session_id": self._session_id},
+            database=self._database,
         )
 
     @property
@@ -83,6 +84,7 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
                 node_label=self._node_label, window=self._window * 2
             ),
             {"session_id": self._session_id},
+            database=self._database,
         )
         messages = [
             {
@@ -109,6 +111,7 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
                 "content": message.content,
                 "session_id": self._session_id,
             },
+            database=self._database,
         )
 
     def clear(self, delete_session_node: bool = False) -> None:
@@ -124,11 +127,13 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
                     node_label=self._node_label
                 ),
                 parameters_={"session_id": self._session_id},
+                database=self._database,
             )
         else:
             self._driver.execute_query(
                 query_=DELETE_MESSAGES_QUERY.format(node_label=self._node_label),
                 parameters_={"session_id": self._session_id},
+                database=self._database,
             )
 
     def __del__(self) -> None:

--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -153,7 +153,7 @@ class Neo4jVector(VectorStore):
 
             url="bolt://localhost:7687"
             username="neo4j"
-            password="pleaseletmein"
+            password="password"
             embeddings = OpenAIEmbeddings()
             vectorestore = Neo4jVector.from_documents(
                 embedding=embeddings,

--- a/libs/neo4j/tests/integration_tests/conftest.py
+++ b/libs/neo4j/tests/integration_tests/conftest.py
@@ -7,7 +7,7 @@ from tests.integration_tests.utils import Neo4jCredentials
 
 url = os.environ.get("NEO4J_URI", "bolt://localhost:7687")
 username = os.environ.get("NEO4J_USERNAME", "neo4j")
-password = os.environ.get("NEO4J_PASSWORD", "pleaseletmein")
+password = os.environ.get("NEO4J_PASSWORD", "password")
 os.environ["NEO4J_URI"] = url
 os.environ["NEO4J_USERNAME"] = username
 os.environ["NEO4J_PASSWORD"] = password

--- a/libs/neo4j/tests/integration_tests/docker-compose/neo4j.yml
+++ b/libs/neo4j/tests/integration_tests/docker-compose/neo4j.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   neo4j:
-    image: neo4j:5.24
+    image: neo4j:5.24.2-enterprise
     restart: on-failure:0
     hostname: neo4j-test
     container_name: neo4j-test
@@ -9,6 +9,7 @@ services:
       - 7474:7474
       - 7687:7687
     environment:
-      NEO4J_AUTH: neo4j/pleaseletmein
+      NEO4J_AUTH: neo4j/password
+      NEO4J_ACCEPT_LICENSE_AGREEMENT: "eval"
       NEO4J_PLUGINS: "[\"apoc\"]"
 


### PR DESCRIPTION
# Description

- Gives developers the ability to use custom DBs with Neo4jChatMessageHistory
- Adds an integration test for the above
- Changes the default password for the integration tests Neo4j Docker container from `pleaseletmein` to `password`
- Updates the version of Neo4j used by the integration tests from neo4j:5.24 to neo4j:5.24.2-enterprise

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

## Checklist

- [ ] Unit tests updated
- [X] Integration tests updated
- [ ] CHANGELOG.md updated
