### PR TITLE
Fix in query corrector variable detection

### DIFF
--- a/libs/neo4j/langchain_neo4j/chains/graph_qa/cypher_utils.py
+++ b/libs/neo4j/langchain_neo4j/chains/graph_qa/cypher_utils.py
@@ -51,7 +51,7 @@ class CypherQueryCorrector:
         res: Dict[str, Any] = {}
         for node in nodes:
             parts = node.split(":")
-            if parts == "":
+            if parts[0] == "":
                 continue
             variable = parts[0]
             if variable not in res:


### PR DESCRIPTION
# Description

> **Note**
>
> Please provide a description of the work completed in this PR
>
>
This small mistake in the query corrctor makes in some cases the detected variable dict to have in the variable `""` (empty string) all the node lables from the nodes that don't have a variable, and in the end it doesn't correct the query properly (it thinks every node without a variable has all the node labels).

Looking at the code, it is obvious that the original author forgot to add the `[0]` since the if statement compares an array to an empty string.

Also PR in the original corrector repo: https://github.com/sakusaku-rich/cypher-direction-competition/pull/8


## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High
>
>
Low

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

## Checklist

- [ ] Unit tests updated
- [ ] Integration tests updated
- [ ] CHANGELOG.md updated
