### PR TITLE
Bumps langchain-core patch version

### DIFF
--- a/libs/neo4j/poetry.lock
+++ b/libs/neo4j/poetry.lock
@@ -1932,4 +1932,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.14"
-content-hash = "d6efe230d0bad7c926af31fcf5105e3c420abc3b60b62173b289d50e44e13a8c"
+content-hash = "ffa8faef3e62bc079bd9f2339215201d3448a4903e3c635cadb11e7ca0404202"

--- a/libs/neo4j/pyproject.toml
+++ b/libs/neo4j/pyproject.toml
@@ -13,7 +13,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.14"
-langchain-core = "^0.3.8"
+langchain-core = "^0.3.39"
 neo4j = "^5.25.0"
 langchain = "^0.3.7"
 neo4j-graphrag = "^1.9.0"


### PR DESCRIPTION
# Description

The [0.5.0 release workflow](https://github.com/langchain-ai/langchain-neo4j/actions/runs/16518623800/job/46715131584) was failing. The cause of this was a [Pydantic issue](https://github.com/langchain-ai/langchain/pull/29963) in `langchain-core`. This was fixed in [version 0.3.39](https://github.com/langchain-ai/langchain/releases/tag/langchain-core%3D%3D0.3.39). This PR updates the `langchain-core` dependency with this fix.


## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [X] Unit tests
- [X] Integration tests
- [ ] Manual tests

## Checklist

- [ ] Unit tests updated
- [ ] Integration tests updated
- [ ] CHANGELOG.md updated
