### PR TITLE
Add examples support to GraphCypherQAChain

### DIFF
--- a/libs/neo4j/langchain_neo4j/chains/graph_qa/cypher.py
+++ b/libs/neo4j/langchain_neo4j/chains/graph_qa/cypher.py
@@ -121,6 +121,7 @@ class GraphCypherQAChain(Chain):
     graph_schema: str
     input_key: str = "query"  #: :meta private:
     output_key: str = "result"  #: :meta private:
+    example_key: str = "examples"
     top_k: int = 10
     """Number of results to return from the query"""
     return_intermediate_steps: bool = False
@@ -324,8 +325,10 @@ class GraphCypherQAChain(Chain):
         _run_manager = run_manager or CallbackManagerForChainRun.get_noop_manager()
         callbacks = _run_manager.get_child()
         question = inputs[self.input_key]
+        examples = inputs.get(self.example_key, None)
         args = {
             "question": question,
+            "examples": examples,
             "schema": self.graph_schema,
         }
         args.update(inputs)

--- a/libs/neo4j/langchain_neo4j/chains/graph_qa/prompts.py
+++ b/libs/neo4j/langchain_neo4j/chains/graph_qa/prompts.py
@@ -11,11 +11,15 @@ Note: Do not include any explanations or apologies in your responses.
 Do not respond to any questions that might ask anything else than for you to construct a Cypher statement.
 Do not include any text except the generated Cypher statement.
 
+Examples (optional):
+{examples}
+
 The question is:
 {question}"""
 
 CYPHER_GENERATION_PROMPT = PromptTemplate(
-    input_variables=["schema", "question"], template=CYPHER_GENERATION_TEMPLATE
+    input_variables=["schema", "examples", "question"],
+    template=CYPHER_GENERATION_TEMPLATE,
 )
 
 CYPHER_QA_TEMPLATE = """You are an assistant that helps to form nice and human understandable answers.


### PR DESCRIPTION
# Description

Added the ability to provide examples to the `GraphCypherQAChain` to improve the quality of the generated Cypher queries. It adds an `example_key` to the chain, updates the prompt template to include examples (optional), and adds a new unit test to verify the functionality. With this, users can run few-shot examples using either dynamic input-output pairs selected via LangChain's example selectors or static examples provided directly.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

## Checklist

- [x] Unit tests updated
- [ ] Integration tests updated
- [ ] CHANGELOG.md updated
