### PR TITLE
Skipped removal of `id` property from search query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixed
 
 - Fixed `GraphCypherQAChain` compatibility with non-Neo4j `GraphStore` implementations (for example `AGEGraph`) by not requiring the private `_enhanced_schema` attribute.
+- Skipped removal of `id` property from search query results, this field can now present in retrieved documents' metadata.
 
 ## 0.8.0
 

--- a/libs/neo4j/README.md
+++ b/libs/neo4j/README.md
@@ -186,7 +186,7 @@ To lint it, run:
 make lint
 ```
 
-To format the `pyproject. ` file, run:
+To format the `pyproject.toml` file, run:
 
 ```bash
 uv run pyprojectsort pyproject.toml

--- a/libs/neo4j/README.md
+++ b/libs/neo4j/README.md
@@ -186,7 +186,7 @@ To lint it, run:
 make lint
 ```
 
-To format the `pyproject.` file, run:
+To format the `pyproject. ` file, run:
 
 ```bash
 uv run pyprojectsort pyproject.toml

--- a/libs/neo4j/README.md
+++ b/libs/neo4j/README.md
@@ -186,7 +186,7 @@ To lint it, run:
 make lint
 ```
 
-To format the `pyproject.toml` file, run:
+To format the `pyproject.` file, run:
 
 ```bash
 uv run pyprojectsort pyproject.toml

--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -740,7 +740,7 @@ class Neo4jVector(VectorStore):
             f"{entity_prefix} "
             "{.*, "
             f"`{self.text_node_property}`: Null, "
-            f"`{self.embedding_node_property}`: Null, id: Null "
+            f"`{self.embedding_node_property}`: Null "
         )
         if kwargs.get("return_embeddings"):
             default_retrieval += (
@@ -1403,7 +1403,7 @@ def _text_node_props_retrieval_query(
         " str + '\\n' + k + ': ' + coalesce(node[k], '')) AS text, "
         "node {.*, `"
         + embedding_node_property
-        + "`: Null, id: Null, "
+        + "`: Null, "
         + ", ".join([f"`{prop}`: Null" for prop in text_node_properties])
         + "} AS metadata, score"
     )

--- a/libs/neo4j/tests/integration_tests/vectorstores/test_neo4jvector.py
+++ b/libs/neo4j/tests/integration_tests/vectorstores/test_neo4jvector.py
@@ -1,5 +1,6 @@
 """Test Neo4jVector functionality."""
 
+import hashlib
 import os
 from typing import Any, Dict, List, cast
 
@@ -28,6 +29,13 @@ from tests.integration_tests.vectorstores.fixtures.filtering_test_cases import (
 OS_TOKEN_COUNT = 1536
 
 texts = ["foo", "bar", "baz", "It is the end of the world. Take shelter!"]
+documents = [
+    Document(
+        page_content=page_content,
+        metadata={"id": hashlib.md5(page_content.encode("utf-8")).hexdigest()},
+    )
+    for page_content in texts
+]
 
 """
 cd tests/integration_tests/docker-compose
@@ -81,7 +89,7 @@ def test_neo4jvector() -> None:
         pre_delete_collection=True,
     )
     output = docsearch.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [documents[0]]
 
     drop_vector_indexes(docsearch)
 
@@ -97,7 +105,7 @@ def test_neo4jvector_euclidean(neo4j_credentials: Neo4jCredentials) -> None:
         **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [documents[0]]
 
     drop_vector_indexes(docsearch)
 
@@ -114,7 +122,7 @@ def test_neo4jvector_embeddings(neo4j_credentials: Neo4jCredentials) -> None:
         **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [documents[0]]
 
     drop_vector_indexes(docsearch)
 
@@ -138,7 +146,7 @@ def test_neo4jvector_catch_wrong_index_name(
         **neo4j_credentials,
     )
     output = existing.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [documents[0]]
 
     drop_vector_indexes(existing)
 
@@ -163,7 +171,7 @@ def test_neo4jvector_catch_wrong_node_label(
         **neo4j_credentials,
     )
     output = existing.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [documents[0]]
 
     drop_vector_indexes(existing)
 
@@ -180,7 +188,12 @@ def test_neo4jvector_with_metadatas(neo4j_credentials: Neo4jCredentials) -> None
         **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo", metadata={"page": "0"})]
+    assert output == [
+        Document(
+            page_content=documents[0].page_content,
+            metadata=documents[0].metadata | {"page": "0"},
+        )
+    ]
 
     drop_vector_indexes(docsearch)
 
@@ -202,7 +215,15 @@ def test_neo4jvector_with_metadatas_with_scores(
         (doc, round(score, 1))
         for doc, score in docsearch.similarity_search_with_score("foo", k=1)
     ]
-    assert output == [(Document(page_content="foo", metadata={"page": "0"}), 1.0)]
+    assert output == [
+        (
+            Document(
+                page_content=documents[0].page_content,
+                metadata=documents[0].metadata | {"page": "0"},
+            ),
+            1.0,
+        )
+    ]
 
     drop_vector_indexes(docsearch)
 
@@ -254,7 +275,10 @@ def test_neo4jvector_retriever_search_threshold(
     output = retriever.invoke("foo")
 
     assert output == [
-        Document(page_content="foo", metadata={"page": "0"}),
+        Document(
+            page_content=documents[0].page_content,
+            metadata=documents[0].metadata | {"page": "0"},
+        ),
     ]
 
     drop_vector_indexes(docsearch)
@@ -305,7 +329,7 @@ def test_neo4jvector_prefer_indexname(neo4j_credentials: Neo4jCredentials) -> No
     )
 
     output = existing_index.similarity_search("bar", k=1)
-    assert output == [Document(page_content="bar", metadata={})]
+    assert output == [documents[1]]
     drop_vector_indexes(existing_index)
 
 
@@ -342,10 +366,7 @@ def test_neo4jvector_prefer_indexname_insert(
     existing_index.add_documents([Document(page_content="bar", metadata={})])
 
     output = existing_index.similarity_search("bar", k=2)
-    assert output == [
-        Document(page_content="bar", metadata={}),
-        Document(page_content="foo", metadata={}),
-    ]
+    assert output == [documents[1], documents[0]]
     drop_vector_indexes(existing_index)
 
 
@@ -362,7 +383,7 @@ def test_neo4jvector_hybrid(neo4j_credentials: Neo4jCredentials) -> None:
         **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [documents[0]]
 
     drop_vector_indexes(docsearch)
 
@@ -381,11 +402,7 @@ def test_neo4jvector_hybrid_deduplicate(neo4j_credentials: Neo4jCredentials) -> 
     )
     output = docsearch.similarity_search("foo", k=3)
 
-    assert output == [
-        Document(page_content="foo"),
-        Document(page_content="It is the end of the world. Take shelter!"),
-        Document(page_content="baz"),
-    ]
+    assert output == [documents[0], documents[3], documents[2]]
 
     drop_vector_indexes(docsearch)
 
@@ -478,7 +495,7 @@ def test_neo4jvector_hybrid_from_existing(neo4j_credentials: Neo4jCredentials) -
     )
 
     output = existing.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [documents[0]]
 
     drop_vector_indexes(existing)
 
@@ -638,9 +655,7 @@ def test_neo4jvector_special_character(neo4j_credentials: Neo4jCredentials) -> N
         k=1,
     )
 
-    assert output == [
-        Document(page_content="It is the end of the world. Take shelter!", metadata={})
-    ]
+    assert output == [documents[3]]
 
     drop_vector_indexes(docsearch)
 
@@ -807,8 +822,6 @@ def test_metadata_filters_type1(neo4j_credentials: Neo4jCredentials) -> None:
         # We don't return id properties from similarity search by default
         # Also remove any key where the value is None
         for doc in expected_output:
-            if "id" in doc.metadata:
-                del doc.metadata["id"]
             keys_with_none = [
                 key for key, value in doc.metadata.items() if value is None
             ]
@@ -993,7 +1006,7 @@ def test_neo4jvector_passing_graph_object(neo4j_credentials: Neo4jCredentials) -
         **neo4j_credentials,
     )
     output = docsearch.similarity_search("foo", k=1)
-    assert output == [Document(page_content="foo")]
+    assert output == [documents[0]]
 
     drop_vector_indexes(docsearch)
     os.environ["NEO4J_URI"] = old_url

--- a/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
+++ b/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
@@ -1,3 +1,4 @@
+import os
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
@@ -150,7 +151,14 @@ def test_neo4j_graph_init_with_token() -> None:
 
 def test_neo4j_graph_init_without_credentials() -> None:
     """Test the __init__ method raises error when no credentials are provided."""
-    with patch("neo4j.GraphDatabase.driver", autospec=True) as mock_driver:
+    with (
+        patch("neo4j.GraphDatabase.driver", autospec=True) as mock_driver,
+        patch.dict(os.environ),
+    ):
+        os.environ.pop("NEO4J_URI", None)
+        os.environ.pop("NEO4J_USERNAME", None)
+        os.environ.pop("NEO4J_PASSWORD", None)
+
         mock_driver_instance = MagicMock()
         mock_driver.return_value = mock_driver_instance
         mock_driver_instance.verify_connectivity.return_value = None


### PR DESCRIPTION
# Description

Fixes #109

- Removed explicit `id: Null` property setting in search queries `RETURN` part. This now enables retrieval of the `id` property for nodes and relationships. This is not a breaking change, because before this change the property was never present, regardless of whether it was missing, set in the process of adding documents, or manually added by the user.
- Fixed integration tests so the `id` field can be present in the metadata. This doesn't apply to relationship vector index search tests, because there the `id` field is not set there.
- Fixed the `test_neo4j_graph_init_without_credentials` unit test so it passes when in a single test run both integration and unit tests are executed. Previously it was failing, because the credentials set by integration tests were available in the environment variables.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Medium

## How Has This Been Tested?

- [ ] Unit tests (Not applicable for this PR in my opinion, the integration tests cover everything)
- [x] Integration tests
- [x] Manual tests

## Checklist

- [x] Unit tests updated
- [x] Integration tests updated
- [x] CHANGELOG.md updated
