### PR TITLE
Relationship index ingestion exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Fixed
 
 - Fixed `GraphCypherQAChain` compatibility with non-Neo4j `GraphStore` implementations (for example `AGEGraph`) by not requiring the private `_enhanced_schema` attribute.
+- Added `DataIngestionNotSupported` exception to be raised when trying to ingest data to a relationship index.
 
 ## 0.8.0
 

--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -111,6 +111,13 @@ def dict_to_yaml_str(input_dict: Dict, indent: int = 0) -> str:
     return yaml_str
 
 
+class DataIngestionNotSupported(ValueError):
+    """Data ingestion is not supported with relationship vector index."""
+
+    def __init__(self) -> None:
+        super().__init__(self.__doc__)
+
+
 class Neo4jVector(VectorStore):
     """Neo4j vector index.
 
@@ -500,10 +507,8 @@ class Neo4jVector(VectorStore):
             index_type = None
 
         # Raise error if relationship index type
-        if index_type == "RELATIONSHIP":
-            raise ValueError(
-                "Data ingestion is not supported with relationship vector index."
-            )
+        if index_type == IndexType.RELATIONSHIP:
+            raise DataIngestionNotSupported
 
         # If the vector index doesn't exist yet
         if not index_type:
@@ -560,6 +565,10 @@ class Neo4jVector(VectorStore):
             metadatas: List of metadatas associated with the texts.
             kwargs: `VectorStore` specific parameters
         """
+
+        if self._index_type == IndexType.RELATIONSHIP:
+            raise DataIngestionNotSupported
+
         if ids is None:
             ids = [md5(text.encode("utf-8")).hexdigest() for text in texts]
 
@@ -624,6 +633,10 @@ class Neo4jVector(VectorStore):
         Returns:
             List of IDs from adding the texts into the `VectorStore`.
         """
+
+        if self._index_type == IndexType.RELATIONSHIP:
+            raise DataIngestionNotSupported
+
         embeddings = self.embedding.embed_documents(list(texts))
         return self.add_embeddings(
             texts=texts, embeddings=embeddings, metadatas=metadatas, ids=ids, **kwargs

--- a/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
+++ b/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
@@ -5,9 +5,11 @@ from unittest.mock import MagicMock, patch
 
 import neo4j
 import pytest
+from neo4j_graphrag.types import EntityType as IndexType
 from neo4j_graphrag.types import SearchType
 
 from langchain_neo4j.vectorstores.neo4j_vector import (
+    DataIngestionNotSupported,
     Neo4jVector,
     check_if_not_null,
     dict_to_yaml_str,
@@ -968,3 +970,37 @@ def test_from_existing_index_without_text_node_properties(
 
     # Without text_node_properties, retrieval_query should be empty (uses default)
     assert vector_store.retrieval_query == ""
+
+
+def test_add_embeddings_relationship_index(mock_vector_store: Neo4jVector) -> None:
+    """
+    Test that add_embeddings raises DataIngestionNotSupported
+    when relationship index is used.
+    """
+
+    mock_vector_store._index_type = IndexType.RELATIONSHIP
+
+    with pytest.raises(DataIngestionNotSupported) as exc_info:
+        mock_vector_store.add_embeddings(texts=["some_text"], embeddings=[[0] * 64])
+
+    assert (
+        str(exc_info.value)
+        == "Data ingestion is not supported with relationship vector index."
+    )
+
+
+def test_add_texts_relationship_index(mock_vector_store: Neo4jVector) -> None:
+    """
+    Test that add_texts raises DataIngestionNotSupported
+    when relationship index is used.
+    """
+
+    mock_vector_store._index_type = IndexType.RELATIONSHIP
+
+    with pytest.raises(DataIngestionNotSupported) as exc_info:
+        mock_vector_store.add_texts(texts=["some_text"])
+
+    assert (
+        str(exc_info.value)
+        == "Data ingestion is not supported with relationship vector index."
+    )


### PR DESCRIPTION
# Description

Fixes #111 

Added `DataIngestionNotSupported` exception to be raised when trying to ingest data to a relationship index. This exception inherits from `ValueError`, which implies that the exception type change in `__from` is backwards compatible. This can be confirmed by running the `test_neo4jvector_relationship_index_error` test, which was not changed as part of this PR.

After these changes, the example in the related issue is now raising the exception instead of creating nodes:
```py
>>> neo4j_vector.add_texts(["My text", "My other text"])
DataIngestionNotSupported: Data ingestion is not supported with relationship vector index.
```

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Project configuration change

## Complexity

Medium

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests (not applicable here in my opinion, unit tests cover this scenario well enough)
- [x] Manual tests

## Checklist

- [x] Unit tests updated
- [ ] Integration tests updated
- [x] CHANGELOG.md updated
