### PR TITLE
fix(neo4j): don't mutate shared session_params default in query()

### DIFF
--- a/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
+++ b/libs/neo4j/langchain_neo4j/graphs/neo4j_graph.py
@@ -220,8 +220,8 @@ class Neo4jGraph(GraphStore):
     def query(
         self,
         query: str,
-        params: dict = {},
-        session_params: dict = {},
+        params: Optional[dict] = None,
+        session_params: Optional[dict] = None,
     ) -> List[Dict[str, Any]]:
         """Query Neo4j database.
 
@@ -240,6 +240,13 @@ class Neo4jGraph(GraphStore):
         self._check_driver_state()
         from neo4j import Query
         from neo4j.exceptions import Neo4jError
+
+        params = params or {}
+        # Work on a fresh dict so the implicit-transaction fallback below never
+        # mutates a shared mutable default (or the caller's dict). A mutable
+        # default here leaked one instance's database into other Neo4jGraph
+        # instances via ``session_params.setdefault("database", ...)``.
+        session_params = dict(session_params) if session_params else {}
 
         if not session_params:
             try:

--- a/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
+++ b/libs/neo4j/tests/unit_tests/graphs/test_neo4j_graph.py
@@ -253,6 +253,43 @@ def test_query_fallback_execution(mock_neo4j_driver: MagicMock) -> None:
     assert json_data == [{"key1": "value1"}]
 
 
+def test_query_fallback_does_not_leak_database_across_instances(
+    mock_neo4j_driver: MagicMock,
+) -> None:
+    """The implicit-transaction fallback must not mutate the shared ``session_params``
+    default; otherwise one ``Neo4jGraph``'s database leaks into another's queries."""
+    err = Neo4jError._basic_hydrate(
+        neo4j_code="Neo.DatabaseError.Statement.ExecutionFailed",
+        message="in an implicit transaction",
+    )
+    mock_neo4j_driver.execute_query.side_effect = err
+    mock_session = MagicMock()
+    mock_session.run.return_value = []
+    mock_neo4j_driver.session.return_value.__enter__.return_value = mock_session
+    mock_neo4j_driver.session.return_value.__exit__.return_value = None
+
+    graph_a = Neo4jGraph(
+        url="bolt://localhost:7687",
+        username="neo4j",
+        password="password",
+        database="db_a",
+        refresh_schema=False,
+    )
+    graph_a.query("MATCH (n) RETURN n")  # fallback path, default session_params
+
+    graph_b = Neo4jGraph(
+        url="bolt://localhost:7687",
+        username="neo4j",
+        password="password",
+        database="db_b",
+        refresh_schema=False,
+    )
+    graph_b.query("MATCH (n) RETURN n")
+
+    # graph_b must run against its OWN database, not graph_a's.
+    mock_neo4j_driver.session.assert_called_with(database="db_b")
+
+
 def test_refresh_schema_handles_client_error(mock_neo4j_driver: MagicMock) -> None:
     """Test refresh schema handles a client error which might arise due to a user
     not having access to schema information"""


### PR DESCRIPTION
## Why

`Neo4jGraph.query` declares mutable default arguments:

```python
def query(self, query, params: dict = {}, session_params: dict = {}):
```

On the implicit-transaction fallback path it does:

```python
session_params.setdefault("database", self._database)
```

When a caller invokes `graph.query(cypher)` without `session_params` and the query needs the fallback (e.g. `CALL {} IN TRANSACTIONS` / `PERIODIC COMMIT`), `session_params` **is** the shared function-level default `{}`, so `setdefault` permanently mutates it to `{"database": <this instance's db>}`. From then on:

1. Every later `query()` on **any** instance sees a truthy `session_params`, so `if not session_params:` is False and the optimized `execute_query` path is skipped.
2. A second `Neo4jGraph` pointing at a **different** database calls `query(cypher)`, gets the polluted default `{"database": <instance A's db>}`, and silently runs against the **wrong database**.

## What

Default `params` and `session_params` to `None` and operate on a fresh dict, so the fallback never mutates shared or caller-owned state. Behaviour is otherwise unchanged.

## Tests

Added `test_query_fallback_does_not_leak_database_across_instances`: it drives two `Neo4jGraph` instances (databases `db_a`, `db_b`) through the fallback and asserts the second runs against `db_b`. It fails on `main` (routes to `db_a`) and passes with the fix. Full `test_neo4j_graph.py`: **15 passed**; `ruff` and `mypy` clean. (Note: the existing `test_query_fallback_execution` was itself silently polluting the shared default as a side effect — that latent test-order coupling is also removed.)

## Areas worth a careful look

- `params` was not mutated, but it is fixed for the same reason (mutable default argument) and to keep the two parameters consistent; the `params = params or {}` normalization preserves existing behaviour.

---

🤖 *AI disclosure:* found by an automated code-review pass and fixed/tested with Claude Code (an AI coding agent). The regression is pinned by the new test.
