### PR TITLE
fix(neo4j): allow similarity_search_by_vector without a query kwarg

### DIFF
--- a/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
+++ b/libs/neo4j/langchain_neo4j/vectorstores/neo4j_vector.py
@@ -780,7 +780,13 @@ class Neo4jVector(VectorStore):
             "top_k": k,
             "query_vector": embedding,
             "fulltext_index_name": self.keyword_index_name,
-            "query_text": remove_lucene_chars(kwargs["query"]),
+            # query_text is only consumed by hybrid (full-text) search; pure
+            # vector-by-vector callers pass no "query", so default to "" instead
+            # of raising KeyError. (Guard on membership, not .get(), because
+            # remove_lucene_chars(None) would itself raise.)
+            "query_text": remove_lucene_chars(kwargs["query"])
+            if "query" in kwargs
+            else "",
             "effective_search_ratio": effective_search_ratio,
             **params,
             **filter_params,

--- a/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
+++ b/libs/neo4j/tests/unit_tests/vectorstores/test_neo4j.py
@@ -498,6 +498,22 @@ def test_similarity_search_by_vector_metadata_filter_unsupported(
     )
 
 
+def test_similarity_search_by_vector_without_query_kwarg(
+    neo4j_vector_factory: Any,
+) -> None:
+    """Pure vector search via similarity_search_by_vector must not require a
+    'query' kwarg (query_text is only used by hybrid search)."""
+    vector_store = neo4j_vector_factory()
+    vector_store.support_metadata_filter = True
+    vector_store.search_type = SearchType.VECTOR
+    vector_store.embedding_dimension = 64
+
+    with patch.object(Neo4jVector, "query", return_value=[]):
+        docs = vector_store.similarity_search_by_vector(embedding=[0] * 64)
+
+    assert docs == []
+
+
 def test_similarity_search_by_vector_metadata_filter_hybrid(
     neo4j_vector_factory: Any,
 ) -> None:


### PR DESCRIPTION
## Why

`similarity_search_with_score_by_vector` builds its Cypher parameters with:

```python
"query_text": remove_lucene_chars(kwargs["query"]),
```

reading `kwargs["query"]` unconditionally. But the public `similarity_search_by_vector(embedding=[...])` forwards no `query` kwarg, so a pure vector-by-vector search:

```python
store.similarity_search_by_vector(embedding=[0.1] * 64)
```

raises `KeyError: 'query'` — even though `query_text` is only consumed by hybrid full-text search and is irrelevant to pure vector search.

## What

Default `query_text` to `""` when no `query` kwarg is supplied. The guard is on membership (`"query" in kwargs`) rather than `.get()`, because `remove_lucene_chars(None)` would itself raise. Text/hybrid entry points always pass `query`, so their behaviour is unchanged.

## Tests

Added `test_similarity_search_by_vector_without_query_kwarg`: a `VECTOR` store calls `similarity_search_by_vector(embedding=[0]*64)` with no `query`. It fails on `main` (`KeyError: 'query'` at neo4j_vector.py:783) and passes with the fix. Full `test_neo4j.py`: **48 passed**; `ruff` and `mypy` clean.

---

🤖 *AI disclosure:* found by an automated code-review pass and fixed/tested with Claude Code (an AI coding agent). The regression is pinned by the new test.
