### PR TITLE
fix: do not close borrowed driver in Neo4jChatMessageHistory.__del__

### DIFF
--- a/libs/neo4j/langchain_neo4j/chat_message_histories/neo4j.py
+++ b/libs/neo4j/langchain_neo4j/chat_message_histories/neo4j.py
@@ -36,6 +36,8 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
 
         # Graph object takes precedent over env or input params
         if graph:
+            # Driver is borrowed from the caller's Neo4jGraph; do not close it.
+            self._owns_driver = False
             self._driver = graph._driver
             self._database = graph._database
         else:
@@ -52,6 +54,8 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
             )
 
             self._driver = neo4j.GraphDatabase.driver(url, auth=(username, password))
+            # Driver is created and owned here, so it must be closed on delete.
+            self._owns_driver = True
             self._database = database
             # Verify connection
             try:
@@ -136,5 +140,9 @@ class Neo4jChatMessageHistory(BaseChatMessageHistory):
             )
 
     def __del__(self) -> None:
-        if self._driver:
-            self._driver.close()
+        # Only close a driver we created; a driver borrowed from a Neo4jGraph
+        # is owned by the caller and closing it would break their connection.
+        if getattr(self, "_owns_driver", False):
+            driver = getattr(self, "_driver", None)
+            if driver is not None:
+                driver.close()

--- a/libs/neo4j/tests/unit_tests/chat_message_histories/test_neo4j_chat_message_history.py
+++ b/libs/neo4j/tests/unit_tests/chat_message_histories/test_neo4j_chat_message_history.py
@@ -44,3 +44,24 @@ def test_driver_closed_on_delete() -> None:
         message_store.__del__()
         gc.collect()
         mock_driver.close.assert_called_once()
+
+
+def test_borrowed_driver_not_closed_on_delete() -> None:
+    """A driver borrowed from a Neo4jGraph (``graph=``) must not be closed on delete.
+
+    The history object does not own the shared driver, so closing it on
+    ``__del__`` would break the caller's Neo4jGraph and any other object
+    reusing the same connection.
+    """
+    graph = MagicMock()
+    graph._driver = MagicMock()
+    graph._database = "neo4j"
+    message_store = Neo4jChatMessageHistory(
+        session_id="test_session",
+        graph=graph,
+    )
+    borrowed_driver = message_store._driver
+    assert borrowed_driver is graph._driver
+    message_store.__del__()
+    gc.collect()
+    borrowed_driver.close.assert_not_called()


### PR DESCRIPTION
## Why

`Neo4jChatMessageHistory` can reuse an existing connection when constructed with `graph=<Neo4jGraph>`:

```python
graph = Neo4jGraph(url=..., username=..., password=...)
hist = Neo4jChatMessageHistory(session_id="s1", graph=graph)
```

In that branch `__init__` **aliases** the graph's driver (`self._driver = graph._driver`) instead of creating its own. But `__del__` closed it unconditionally:

```python
def __del__(self) -> None:
    if self._driver:
        self._driver.close()
```

So when the history object is garbage-collected, it closes the driver that the caller's `Neo4jGraph` still owns. The next call breaks even though the caller never closed anything:

```python
del hist            # or hist simply goes out of scope
graph.query("MATCH (n) RETURN n")   # -> neo4j driver-closed error
```

The same happens to any other `Neo4jChatMessageHistory` sharing that graph. (`if self._driver:` does not help — a closed `Driver` is still truthy.)

## What

Track driver ownership and only close what we created:

- `self._owns_driver = False` on the `graph=` (borrowed) path.
- `self._owns_driver = True` on the path that creates the driver (set right after creation, before `verify_connectivity`, so an owned driver is still closed if verification raises).
- `__del__` closes only when `_owns_driver` is true, `getattr`-guarded so a partially constructed instance never raises `AttributeError`.

Public signature is unchanged.

## Tests

- New `test_borrowed_driver_not_closed_on_delete`: a driver borrowed via `graph=` is **not** closed on `__del__`.
- Existing `test_driver_closed_on_delete` (owned driver still closed) stays green.

`make test` (112 passed), `ruff check`, `ruff format --check`, and `mypy` all pass.

---
*Disclosure: this contribution was prepared with the assistance of an AI agent (Claude Code). The root-cause analysis, fix, and tests were reviewed by me before submission.*