### PR TITLE
fix: guard against non-dict elements in async graph transformer parsing

### DIFF
--- a/libs/neo4j/langchain_neo4j/graph_transformers/llm.py
+++ b/libs/neo4j/langchain_neo4j/graph_transformers/llm.py
@@ -959,7 +959,8 @@ class LLMGraphTransformer:
             for rel in parsed_json:
                 # Check if mandatory properties are there
                 if (
-                    not rel.get("head")
+                    not isinstance(rel, dict)
+                    or not rel.get("head")
                     or not rel.get("tail")
                     or not rel.get("relation")
                 ):

--- a/libs/neo4j/tests/unit_tests/graph_transformers/test_llm.py
+++ b/libs/neo4j/tests/unit_tests/graph_transformers/test_llm.py
@@ -191,6 +191,27 @@ async def test_aconvert_to_graph_documents_prompt_based_path() -> None:
     assert graph_doc.relationships[0].type == "WORKS_AT"
 
 
+async def test_aconvert_to_graph_documents_skips_non_dict_elements() -> None:
+    """Async prompt-based path must skip non-dict JSON elements, not crash.
+
+    json_repair can parse the LLM output into a list whose elements are not
+    dicts. The sync process_response guards this with ``not isinstance(rel, dict)``;
+    the async path must do the same, otherwise ``rel.get("head")`` on a string
+    raises ``AttributeError``.
+    """
+    response = '["Person", "Company"]'
+    llm = FakeLLM(queries={"_": response}, sequential_responses=True)
+    transformer = LLMGraphTransformer(llm=llm)
+
+    docs = await transformer.aconvert_to_graph_documents(
+        [Document(page_content="Alice works at Acme")]
+    )
+
+    assert len(docs) == 1
+    assert docs[0].nodes == []
+    assert docs[0].relationships == []
+
+
 # ---------- Strict-mode filtering ----------
 
 


### PR DESCRIPTION
## Why

`LLMGraphTransformer.process_response` (sync) skips non-dict elements coming out of the JSON-repair parse:

```python
for rel in parsed_json:
    if (
        not isinstance(rel, dict)   # <-- guard
        or not rel.get("head")
        or not rel.get("tail")
        or not rel.get("relation")
    ):
        continue
```

The async twin `aprocess_response` was missing the `not isinstance(rel, dict)` clause. On the prompt-based (non function-calling) path — used when the LLM has no native structured output, or `ignore_tool_usage=True` — `json_repair.loads` can return a **list of non-dict elements**, e.g. `["Person", "Company"]`. The async loop then called `rel.get("head")` on a string and crashed:

```
AttributeError: 'str' object has no attribute 'get'
```

The sync path handled the same input safely, so this was a sync/async parity gap.

## What

Add the identical `not isinstance(rel, dict)` guard to `aprocess_response`, so both paths skip non-dict elements instead of raising.

## Tests

- New `test_aconvert_to_graph_documents_skips_non_dict_elements`: async prompt-based path fed `["Person", "Company"]` returns a document with no nodes/relationships instead of raising `AttributeError`.
- Existing `test_aconvert_to_graph_documents_prompt_based_path` (happy path) stays green.

`make test` (unit, 15 in this file / full suite green), `ruff check`, `ruff format --check`, and `mypy` all pass.

---
*Disclosure: this contribution was prepared with the assistance of an AI agent (Claude Code). The analysis, fix, and tests were reviewed by me before submission.*